### PR TITLE
feat: BriefFinancialApproval CRUD with approve/reject workflow (close…

### DIFF
--- a/src/apps/ui/templates/brief_financial_approvals/detail.html
+++ b/src/apps/ui/templates/brief_financial_approvals/detail.html
@@ -1,0 +1,75 @@
+{% extends "base.html" %}
+{% block title %}Brief Financial Approval #{{ bfa.pk }}{% endblock %}
+{% block content %}
+<div class="container mt-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2>Brief Financial Approval #{{ bfa.pk }}</h2>
+    <div>
+      <a href="{% url 'ui:bfa_list' project_pk=bfa.project.pk %}" class="btn btn-outline-secondary">Back</a>
+      {% if bfa.status == 'PENDING' %}
+        <a href="{% url 'ui:bfa_edit' project_pk=bfa.project.pk pk=bfa.pk %}" class="btn btn-outline-primary">Edit</a>
+        <form method="post" action="{% url 'ui:bfa_approve' project_pk=bfa.project.pk pk=bfa.pk %}" class="d-inline">
+          {% csrf_token %}
+          <button type="submit" class="btn btn-success">Approve</button>
+        </form>
+        <form method="post" action="{% url 'ui:bfa_reject' project_pk=bfa.project.pk pk=bfa.pk %}" class="d-inline">
+          {% csrf_token %}
+          <button type="submit" class="btn btn-danger">Reject</button>
+        </form>
+      {% endif %}
+      <a href="{% url 'ui:bfa_delete' project_pk=bfa.project.pk pk=bfa.pk %}" class="btn btn-outline-danger">Delete</a>
+    </div>
+  </div>
+
+  {% if messages %}
+    {% for message in messages %}
+      <div class="alert alert-{{ message.tags }}">{{ message }}</div>
+    {% endfor %}
+  {% endif %}
+
+  <dl class="row">
+    <dt class="col-sm-3">Project</dt>
+    <dd class="col-sm-9">{{ bfa.project.name }}</dd>
+
+    <dt class="col-sm-3">Status</dt>
+    <dd class="col-sm-9">
+      {% if bfa.status == 'APPROVED' %}
+        <span class="badge bg-success">Approved</span>
+      {% elif bfa.status == 'REJECTED' %}
+        <span class="badge bg-danger">Rejected</span>
+      {% else %}
+        <span class="badge bg-warning text-dark">Pending</span>
+      {% endif %}
+    </dd>
+
+    <dt class="col-sm-3">Funding Amount</dt>
+    <dd class="col-sm-9">${{ bfa.funding_amount|floatformat:2 }}</dd>
+
+    <dt class="col-sm-3">Contingency</dt>
+    <dd class="col-sm-9">${{ bfa.contingency_amount|floatformat:2 }}</dd>
+
+    <dt class="col-sm-3">Total</dt>
+    <dd class="col-sm-9"><strong>${{ bfa.total_amount|floatformat:2 }}</strong></dd>
+
+    <dt class="col-sm-3">Delegate Level</dt>
+    <dd class="col-sm-9">{{ bfa.get_delegate_level_display }}</dd>
+
+    <dt class="col-sm-3">MINCOR Reference</dt>
+    <dd class="col-sm-9">{{ bfa.mincor_reference|default:"—" }}</dd>
+
+    <dt class="col-sm-3">Comments</dt>
+    <dd class="col-sm-9">{{ bfa.comments|default:"—" }}</dd>
+
+    <dt class="col-sm-3">Approved By</dt>
+    <dd class="col-sm-9">
+      {% if bfa.approved_by %}{{ bfa.approved_by.get_full_name|default:bfa.approved_by.username }}{% else %}—{% endif %}
+    </dd>
+
+    <dt class="col-sm-3">Approved At</dt>
+    <dd class="col-sm-9">{{ bfa.approved_at|default:"—" }}</dd>
+
+    <dt class="col-sm-3">Created</dt>
+    <dd class="col-sm-9">{{ bfa.created_at }}</dd>
+  </dl>
+</div>
+{% endblock %}

--- a/src/apps/ui/templates/brief_financial_approvals/list.html
+++ b/src/apps/ui/templates/brief_financial_approvals/list.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+{% block title %}Brief Financial Approvals — {{ project.name }}{% endblock %}
+{% block content %}
+<div class="container mt-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2>Brief Financial Approvals</h2>
+    <a href="{% url 'ui:bfa_create' project_pk=project.pk %}" class="btn btn-primary">+ New BFA</a>
+  </div>
+  <p class="text-muted">Project: <strong>{{ project.name }}</strong></p>
+
+  {% if approvals %}
+  <table class="table table-hover">
+    <thead>
+      <tr>
+        <th>Funding Amount</th>
+        <th>Contingency</th>
+        <th>Total</th>
+        <th>Delegate Level</th>
+        <th>Status</th>
+        <th>Approved By</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for bfa in approvals %}
+      <tr>
+        <td>${{ bfa.funding_amount|floatformat:0 }}</td>
+        <td>${{ bfa.contingency_amount|floatformat:0 }}</td>
+        <td>${{ bfa.total_amount|floatformat:0 }}</td>
+        <td>{{ bfa.get_delegate_level_display }}</td>
+        <td>
+          {% if bfa.status == 'APPROVED' %}
+            <span class="badge bg-success">Approved</span>
+          {% elif bfa.status == 'REJECTED' %}
+            <span class="badge bg-danger">Rejected</span>
+          {% else %}
+            <span class="badge bg-warning text-dark">Pending</span>
+          {% endif %}
+        </td>
+        <td>
+          {% if bfa.approved_by %}{{ bfa.approved_by.get_full_name|default:bfa.approved_by.username }}{% else %}—{% endif %}
+        </td>
+        <td>
+          <a href="{% url 'ui:bfa_detail' project_pk=project.pk pk=bfa.pk %}" class="btn btn-sm btn-outline-secondary">View</a>
+          <a href="{% url 'ui:bfa_edit' project_pk=project.pk pk=bfa.pk %}" class="btn btn-sm btn-outline-primary">Edit</a>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="text-muted">No brief financial approvals yet.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/src/apps/ui/urls.py
+++ b/src/apps/ui/urls.py
@@ -100,6 +100,15 @@ urlpatterns = [
     path('funding-agreements/<int:pk>/edit/', views.crud_views.FundingAgreementUpdateView.as_view(), name='funding_agreement_edit'),
     path('funding-agreements/<int:pk>/delete/', views.crud_views.FundingAgreementDeleteView.as_view(), name='funding_agreement_delete'),
 
+    # Brief Financial Approvals (nested under project)
+    path('projects/<int:project_pk>/bfa/', views.crud_views.BriefFinancialApprovalListView.as_view(), name='bfa_list'),
+    path('projects/<int:project_pk>/bfa/create/', views.crud_views.BriefFinancialApprovalCreateView.as_view(), name='bfa_create'),
+    path('projects/<int:project_pk>/bfa/<int:pk>/', views.crud_views.BriefFinancialApprovalDetailView.as_view(), name='bfa_detail'),
+    path('projects/<int:project_pk>/bfa/<int:pk>/edit/', views.crud_views.BriefFinancialApprovalUpdateView.as_view(), name='bfa_edit'),
+    path('projects/<int:project_pk>/bfa/<int:pk>/delete/', views.crud_views.BriefFinancialApprovalDeleteView.as_view(), name='bfa_delete'),
+    path('projects/<int:project_pk>/bfa/<int:pk>/approve/', views.crud_views.BriefFinancialApprovalApproveView.as_view(), name='bfa_approve'),
+    path('projects/<int:project_pk>/bfa/<int:pk>/reject/', views.crud_views.BriefFinancialApprovalRejectView.as_view(), name='bfa_reject'),
+
     # Other existing views
     path('reports/', views.reports_views.reports_dashboard_view, name='reports_dashboard'),
     path('land-infra/', views.land_infra_views.land_projects_list_view, name='land_projects_list'),

--- a/src/apps/ui/views/crud_views.py
+++ b/src/apps/ui/views/crud_views.py
@@ -11,8 +11,10 @@ from django.views.generic import (
 from django.contrib import messages
 from django.shortcuts import get_object_or_404, redirect
 
+from django.utils import timezone
+
 from apps.core.models import (
-    Council, Program, Project, WorkType, FundingSchedule,
+    BriefFinancialApproval, Council, Program, Project, WorkType, FundingSchedule,
     Variation, Payment, StageReport, QuarterlyReport,
     FundingAgreement, FundingNotice, ExpenseClaim,
 )
@@ -779,3 +781,107 @@ class ExpenseClaimRejectView(LoginRequiredMixin, View):
         claim.save()
         messages.info(request, 'Claim rejected.')
         return redirect('ui:funding_notice_detail', pk=notice_pk)
+
+
+# ---------------------------------------------------------------------------
+# BriefFinancialApproval  (nested under project)
+# ---------------------------------------------------------------------------
+
+class BriefFinancialApprovalListView(LoginRequiredMixin, ListView):
+    model = BriefFinancialApproval
+    template_name = 'brief_financial_approvals/list.html'
+    context_object_name = 'approvals'
+
+    def get_queryset(self):
+        return BriefFinancialApproval.objects.filter(project_id=self.kwargs['project_pk'])
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['project'] = get_object_or_404(Project, pk=self.kwargs['project_pk'])
+        return ctx
+
+
+class BriefFinancialApprovalCreateView(LoginRequiredMixin, CreateView):
+    model = BriefFinancialApproval
+    template_name = 'crud/form.html'
+    fields = ['funding_amount', 'contingency_amount', 'delegate_level', 'mincor_reference', 'comments']
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs['instance'] = BriefFinancialApproval(project_id=self.kwargs['project_pk'])
+        return kwargs
+
+    def get_success_url(self):
+        return reverse_lazy('ui:bfa_list', kwargs={'project_pk': self.kwargs['project_pk']})
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['title'] = 'Create Brief Financial Approval'
+        ctx['back_url'] = reverse_lazy('ui:bfa_list', kwargs={'project_pk': self.kwargs['project_pk']})
+        return ctx
+
+
+class BriefFinancialApprovalDetailView(LoginRequiredMixin, DetailView):
+    model = BriefFinancialApproval
+    template_name = 'brief_financial_approvals/detail.html'
+    context_object_name = 'bfa'
+
+
+class BriefFinancialApprovalUpdateView(LoginRequiredMixin, UpdateView):
+    model = BriefFinancialApproval
+    template_name = 'crud/form.html'
+    fields = ['funding_amount', 'contingency_amount', 'delegate_level', 'mincor_reference', 'comments']
+
+    def get_success_url(self):
+        return reverse_lazy('ui:bfa_detail', kwargs={
+            'project_pk': self.kwargs['project_pk'],
+            'pk': self.object.pk,
+        })
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['title'] = f'Edit Brief Financial Approval #{self.object.pk}'
+        ctx['back_url'] = reverse_lazy('ui:bfa_detail', kwargs={
+            'project_pk': self.kwargs['project_pk'],
+            'pk': self.object.pk,
+        })
+        return ctx
+
+
+class BriefFinancialApprovalDeleteView(LoginRequiredMixin, DeleteView):
+    model = BriefFinancialApproval
+    template_name = 'crud/confirm_delete.html'
+
+    def get_success_url(self):
+        return reverse_lazy('ui:bfa_list', kwargs={'project_pk': self.kwargs['project_pk']})
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['back_url'] = reverse_lazy('ui:bfa_list', kwargs={'project_pk': self.kwargs['project_pk']})
+        return ctx
+
+
+class BriefFinancialApprovalApproveView(LoginRequiredMixin, View):
+    def post(self, request, project_pk, pk):
+        bfa = get_object_or_404(BriefFinancialApproval, pk=pk, project_id=project_pk)
+        if bfa.status != BriefFinancialApproval.Status.PENDING:
+            messages.error(request, 'Only pending approvals can be approved.')
+            return redirect('ui:bfa_detail', project_pk=project_pk, pk=pk)
+        bfa.status = BriefFinancialApproval.Status.APPROVED
+        bfa.approved_by = request.user
+        bfa.approved_at = timezone.now()
+        bfa.save()
+        messages.success(request, 'Brief Financial Approval approved.')
+        return redirect('ui:bfa_detail', project_pk=project_pk, pk=pk)
+
+
+class BriefFinancialApprovalRejectView(LoginRequiredMixin, View):
+    def post(self, request, project_pk, pk):
+        bfa = get_object_or_404(BriefFinancialApproval, pk=pk, project_id=project_pk)
+        if bfa.status != BriefFinancialApproval.Status.PENDING:
+            messages.error(request, 'Only pending approvals can be rejected.')
+            return redirect('ui:bfa_detail', project_pk=project_pk, pk=pk)
+        bfa.status = BriefFinancialApproval.Status.REJECTED
+        bfa.save()
+        messages.success(request, 'Brief Financial Approval rejected.')
+        return redirect('ui:bfa_detail', project_pk=project_pk, pk=pk)

--- a/tests/test_bfa_crud.py
+++ b/tests/test_bfa_crud.py
@@ -1,0 +1,188 @@
+"""
+Tests for BriefFinancialApproval CRUD views (issue #14).
+"""
+import pytest
+from decimal import Decimal
+from django.test import Client
+from django.contrib.auth.models import User
+from apps.core.models import BriefFinancialApproval, Profile
+
+
+@pytest.fixture
+def auth_client(council):
+    client = Client()
+    user = User.objects.create_user(username='bfa_user', password='pass')
+    Profile.objects.create(user=user, council=council, officer_role=Profile.OfficerRole.SENIOR_OFFICER)
+    client.force_login(user)
+    return client, user
+
+
+@pytest.fixture
+def bfa(project):
+    return BriefFinancialApproval.objects.create(
+        project=project,
+        funding_amount=Decimal('500000'),
+        contingency_amount=Decimal('50000'),
+        delegate_level=BriefFinancialApproval.DelegateLevel.MANAGER,
+        status=BriefFinancialApproval.Status.PENDING,
+    )
+
+
+@pytest.mark.django_db
+class TestBFAList:
+    def test_list_get(self, auth_client, project):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/bfa/')
+        assert response.status_code == 200
+
+    def test_list_shows_bfa(self, auth_client, project, bfa):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/bfa/')
+        assert response.status_code == 200
+        assert b'500000' in response.content or b'500,000' in response.content
+
+    def test_list_requires_login(self, project):
+        response = Client().get(f'/projects/{project.pk}/bfa/')
+        assert response.status_code == 302
+        assert '/accounts/login/' in response['Location']
+
+
+@pytest.mark.django_db
+class TestBFACreate:
+    def test_create_get(self, auth_client, project):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/bfa/create/')
+        assert response.status_code == 200
+
+    def test_create_post_creates_object(self, auth_client, project):
+        client, _ = auth_client
+        response = client.post(f'/projects/{project.pk}/bfa/create/', {
+            'funding_amount': '750000',
+            'contingency_amount': '75000',
+            'delegate_level': 'DIR',
+            'mincor_reference': 'MINCOR-001',
+            'comments': 'Test approval',
+        }, follow=True)
+        assert response.status_code == 200
+        assert BriefFinancialApproval.objects.filter(project=project, funding_amount=Decimal('750000')).exists()
+
+    def test_create_sets_project_from_url(self, auth_client, project):
+        client, _ = auth_client
+        client.post(f'/projects/{project.pk}/bfa/create/', {
+            'funding_amount': '200000',
+            'contingency_amount': '0',
+            'delegate_level': 'MGR',
+        })
+        bfa = BriefFinancialApproval.objects.filter(project=project).first()
+        assert bfa is not None
+        assert bfa.project == project
+
+    def test_create_requires_login(self, project):
+        response = Client().get(f'/projects/{project.pk}/bfa/create/')
+        assert response.status_code == 302
+
+
+@pytest.mark.django_db
+class TestBFADetail:
+    def test_detail_get(self, auth_client, project, bfa):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/bfa/{bfa.pk}/')
+        assert response.status_code == 200
+
+    def test_detail_shows_amounts(self, auth_client, project, bfa):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/bfa/{bfa.pk}/')
+        assert b'500000' in response.content or b'500,000' in response.content
+
+    def test_detail_shows_approve_button_when_pending(self, auth_client, project, bfa):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/bfa/{bfa.pk}/')
+        assert b'Approve' in response.content
+
+    def test_detail_404_on_missing(self, auth_client, project):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/bfa/99999/')
+        assert response.status_code == 404
+
+
+@pytest.mark.django_db
+class TestBFAEdit:
+    def test_edit_get(self, auth_client, project, bfa):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/bfa/{bfa.pk}/edit/')
+        assert response.status_code == 200
+
+    def test_edit_post_updates_object(self, auth_client, project, bfa):
+        client, _ = auth_client
+        client.post(f'/projects/{project.pk}/bfa/{bfa.pk}/edit/', {
+            'funding_amount': '600000',
+            'contingency_amount': '60000',
+            'delegate_level': 'DIR',
+            'mincor_reference': '',
+            'comments': '',
+        })
+        bfa.refresh_from_db()
+        assert bfa.funding_amount == Decimal('600000')
+        assert bfa.delegate_level == 'DIR'
+
+
+@pytest.mark.django_db
+class TestBFADelete:
+    def test_delete_get(self, auth_client, project, bfa):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/bfa/{bfa.pk}/delete/')
+        assert response.status_code == 200
+
+    def test_delete_post_removes_object(self, auth_client, project, bfa):
+        client, _ = auth_client
+        bfa_id = bfa.pk
+        client.post(f'/projects/{project.pk}/bfa/{bfa_id}/delete/')
+        assert not BriefFinancialApproval.objects.filter(pk=bfa_id).exists()
+
+
+@pytest.mark.django_db
+class TestBFAApproveReject:
+    def test_approve_sets_status_and_user(self, auth_client, project, bfa):
+        client, user = auth_client
+        response = client.post(f'/projects/{project.pk}/bfa/{bfa.pk}/approve/', follow=True)
+        assert response.status_code == 200
+        bfa.refresh_from_db()
+        assert bfa.status == BriefFinancialApproval.Status.APPROVED
+        assert bfa.approved_by == user
+        assert bfa.approved_at is not None
+
+    def test_reject_sets_status(self, auth_client, project, bfa):
+        client, _ = auth_client
+        client.post(f'/projects/{project.pk}/bfa/{bfa.pk}/reject/')
+        bfa.refresh_from_db()
+        assert bfa.status == BriefFinancialApproval.Status.REJECTED
+
+    def test_cannot_approve_already_approved(self, auth_client, project, bfa):
+        client, user = auth_client
+        bfa.status = BriefFinancialApproval.Status.APPROVED
+        bfa.approved_by = user
+        bfa.save()
+        response = client.post(f'/projects/{project.pk}/bfa/{bfa.pk}/approve/', follow=True)
+        assert response.status_code == 200
+        bfa.refresh_from_db()
+        assert bfa.status == BriefFinancialApproval.Status.APPROVED
+
+    def test_cannot_reject_already_rejected(self, auth_client, project, bfa):
+        client, _ = auth_client
+        bfa.status = BriefFinancialApproval.Status.REJECTED
+        bfa.save()
+        response = client.post(f'/projects/{project.pk}/bfa/{bfa.pk}/reject/', follow=True)
+        assert response.status_code == 200
+        bfa.refresh_from_db()
+        assert bfa.status == BriefFinancialApproval.Status.REJECTED
+
+    def test_approve_requires_post(self, auth_client, project, bfa):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/bfa/{bfa.pk}/approve/')
+        assert response.status_code == 405
+
+    def test_total_amount_after_approval(self, auth_client, project, bfa):
+        client, _ = auth_client
+        client.post(f'/projects/{project.pk}/bfa/{bfa.pk}/approve/')
+        bfa.refresh_from_db()
+        assert bfa.total_amount == Decimal('550000')


### PR DESCRIPTION
…s #14)

- List/create/detail/edit/delete views nested under /projects/<pk>/bfa/
- Approve and reject POST actions with guard against double-transition
- approved_by and approved_at stamped on approval
- 21 tests covering all views, state transitions, and login enforcement

## Summary
Explain what this PR does and why.

Fixes #<issue_number>  <!-- Link the issue this PR resolves -->

## Changes
- [x] Describe key changes (models, views, forms, etc.)
- [x] Add migrations if applicable
- [x] Update tests / add new ones

## Testing
Describe how you tested the changes:
- [ ] Ran `python manage.py check`
- [ ] Verified `runserver` starts successfully
- [ ] Manual browser test on affected routes
- [ ] Unit tests pass (`pytest` or Django test suite)

## Notes
Anything reviewers or Roo Code should be aware of (e.g. partial fixes, TODOs, dependencies).