### PR TITLE
feat(issues-15-18-19): Approval, Work & Address CRUD; PaymentRule read-only

### DIFF
--- a/src/apps/ui/templates/addresses/detail.html
+++ b/src/apps/ui/templates/addresses/detail.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% block title %}Address: {{ address }}{% endblock %}
+{% block content %}
+<div class="container mt-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2>{{ address }}</h2>
+    <div>
+      <a href="{% url 'ui:address_edit' project_pk=address.project_id pk=address.pk %}" class="btn btn-outline-primary">Edit</a>
+      <a href="{% url 'ui:address_delete' project_pk=address.project_id pk=address.pk %}" class="btn btn-outline-danger">Delete</a>
+      <a href="{% url 'ui:address_list' project_pk=address.project_id %}" class="btn btn-outline-secondary">Back</a>
+    </div>
+  </div>
+
+  <dl class="row">
+    <dt class="col-sm-3">Project</dt>
+    <dd class="col-sm-9">{{ address.project.name }}</dd>
+
+    <dt class="col-sm-3">Street</dt>
+    <dd class="col-sm-9">{{ address.street }}</dd>
+
+    <dt class="col-sm-3">Suburb</dt>
+    <dd class="col-sm-9">{% if address.suburb %}{{ address.suburb.name }} {{ address.suburb.postcode }} ({{ address.suburb.state }}){% else %}—{% endif %}</dd>
+
+    <dt class="col-sm-3">Lot</dt>
+    <dd class="col-sm-9">{{ address.lot|default:"—" }}</dd>
+
+    <dt class="col-sm-3">Plan</dt>
+    <dd class="col-sm-9">{{ address.plan|default:"—" }}</dd>
+
+    <dt class="col-sm-3">Reside PLC Ref</dt>
+    <dd class="col-sm-9">{{ address.residence_plc_ref|default:"—" }}</dd>
+  </dl>
+</div>
+{% endblock %}

--- a/src/apps/ui/templates/addresses/list.html
+++ b/src/apps/ui/templates/addresses/list.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+{% block title %}Addresses — {{ project.name }}{% endblock %}
+{% block content %}
+<div class="container mt-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2>Addresses</h2>
+    <a href="{% url 'ui:address_create' project_pk=project.pk %}" class="btn btn-primary">+ Add Address</a>
+  </div>
+  <p class="text-muted">Project: <strong>{{ project.name }}</strong></p>
+
+  {% if addresses %}
+  <table class="table table-hover">
+    <thead>
+      <tr>
+        <th>Street</th>
+        <th>Suburb</th>
+        <th>Lot / Plan</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for addr in addresses %}
+      <tr>
+        <td>{{ addr.street }}</td>
+        <td>{% if addr.suburb %}{{ addr.suburb.name }} {{ addr.suburb.postcode }}{% else %}—{% endif %}</td>
+        <td>{% if addr.lot %}Lot {{ addr.lot }}{% endif %}{% if addr.plan %} on {{ addr.plan }}{% endif %}{% if not addr.lot and not addr.plan %}—{% endif %}</td>
+        <td>
+          <a href="{% url 'ui:address_detail' project_pk=project.pk pk=addr.pk %}" class="btn btn-sm btn-outline-secondary">View</a>
+          <a href="{% url 'ui:address_edit' project_pk=project.pk pk=addr.pk %}" class="btn btn-sm btn-outline-primary">Edit</a>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="text-muted">No addresses yet.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/src/apps/ui/templates/approvals/detail.html
+++ b/src/apps/ui/templates/approvals/detail.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+{% block title %}Approval #{{ approval.pk }}{% endblock %}
+{% block content %}
+<div class="container mt-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2>{{ approval.get_approval_type_display }} Approval</h2>
+    <a href="{% url 'ui:approval_list' %}" class="btn btn-outline-secondary">Back</a>
+  </div>
+
+  <dl class="row">
+    <dt class="col-sm-3">Type</dt>
+    <dd class="col-sm-9">{{ approval.get_approval_type_display }}</dd>
+
+    <dt class="col-sm-3">Entity</dt>
+    <dd class="col-sm-9">{{ approval.entity_type }} #{{ approval.entity_id }}</dd>
+
+    <dt class="col-sm-3">Required Role</dt>
+    <dd class="col-sm-9">{{ approval.get_required_role_display }}</dd>
+
+    <dt class="col-sm-3">Status</dt>
+    <dd class="col-sm-9">
+      {% if approval.status == 'APPROVED' %}<span class="badge bg-success">Approved</span>
+      {% elif approval.status == 'REJECTED' %}<span class="badge bg-danger">Rejected</span>
+      {% else %}<span class="badge bg-warning text-dark">Pending</span>{% endif %}
+    </dd>
+
+    <dt class="col-sm-3">Approved By</dt>
+    <dd class="col-sm-9">{% if approval.approved_by %}{{ approval.approved_by.get_full_name|default:approval.approved_by.username }}{% else %}—{% endif %}</dd>
+
+    <dt class="col-sm-3">Approved At</dt>
+    <dd class="col-sm-9">{{ approval.approved_at|default:"—" }}</dd>
+
+    <dt class="col-sm-3">Comments</dt>
+    <dd class="col-sm-9">{{ approval.comments|default:"—" }}</dd>
+
+    <dt class="col-sm-3">Created</dt>
+    <dd class="col-sm-9">{{ approval.created_at|date:"d M Y H:i" }}</dd>
+  </dl>
+
+  {% if approval.status == 'PENDING' %}
+  <div class="mt-3 d-flex gap-2">
+    <form method="post" action="{% url 'ui:approval_approve' pk=approval.pk %}">
+      {% csrf_token %}
+      <button type="submit" class="btn btn-success">Approve</button>
+    </form>
+    <form method="post" action="{% url 'ui:approval_reject' pk=approval.pk %}">
+      {% csrf_token %}
+      <button type="submit" class="btn btn-danger">Reject</button>
+    </form>
+  </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/src/apps/ui/templates/approvals/list.html
+++ b/src/apps/ui/templates/approvals/list.html
@@ -1,0 +1,68 @@
+{% extends "base.html" %}
+{% block title %}Approvals{% endblock %}
+{% block content %}
+<div class="container mt-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2>Approvals</h2>
+  </div>
+
+  <form method="get" class="row g-2 mb-3">
+    <div class="col-auto">
+      <select name="type" class="form-select form-select-sm">
+        <option value="">All types</option>
+        {% for val, label in approval_types %}
+        <option value="{{ val }}" {% if selected_type == val %}selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-auto">
+      <select name="status" class="form-select form-select-sm">
+        <option value="">All statuses</option>
+        {% for val, label in status_choices %}
+        <option value="{{ val }}" {% if selected_status == val %}selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-auto">
+      <button type="submit" class="btn btn-sm btn-outline-primary">Filter</button>
+    </div>
+  </form>
+
+  {% if approvals %}
+  <table class="table table-hover">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Entity</th>
+        <th>Required Role</th>
+        <th>Status</th>
+        <th>Approved By</th>
+        <th>Created</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for approval in approvals %}
+      <tr>
+        <td>{{ approval.get_approval_type_display }}</td>
+        <td>{{ approval.entity_type }} #{{ approval.entity_id }}</td>
+        <td>{{ approval.get_required_role_display }}</td>
+        <td>
+          {% if approval.status == 'APPROVED' %}<span class="badge bg-success">Approved</span>
+          {% elif approval.status == 'REJECTED' %}<span class="badge bg-danger">Rejected</span>
+          {% else %}<span class="badge bg-warning text-dark">Pending</span>{% endif %}
+        </td>
+        <td>{% if approval.approved_by %}{{ approval.approved_by.get_full_name|default:approval.approved_by.username }}{% else %}—{% endif %}</td>
+        <td>{{ approval.created_at|date:"d M Y" }}</td>
+        <td>
+          <a href="{% url 'ui:approval_detail' pk=approval.pk %}" class="btn btn-sm btn-outline-secondary">View</a>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="text-muted">No approvals found.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/src/apps/ui/templates/payment_rules/detail.html
+++ b/src/apps/ui/templates/payment_rules/detail.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+{% block title %}Payment Rule: {{ payment_rule.name }}{% endblock %}
+{% block content %}
+<div class="container mt-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2>{{ payment_rule.name }} <small class="text-muted">v{{ payment_rule.version }}</small></h2>
+    <a href="{% url 'ui:payment_rule_list' %}" class="btn btn-outline-secondary">Back</a>
+  </div>
+
+  {% if schedule_count %}
+  <div class="alert alert-warning">This rule is linked to {{ schedule_count }} funding schedule{{ schedule_count|pluralize }} and is <strong>immutable</strong>.</div>
+  {% endif %}
+
+  <dl class="row">
+    <dt class="col-sm-3">Type</dt>
+    <dd class="col-sm-9">{{ payment_rule.get_rule_type_display }}</dd>
+
+    <dt class="col-sm-3">Version</dt>
+    <dd class="col-sm-9">{{ payment_rule.version }}</dd>
+
+    <dt class="col-sm-3">Active</dt>
+    <dd class="col-sm-9">{% if payment_rule.is_active %}Yes{% else %}No{% endif %}</dd>
+
+    <dt class="col-sm-3">Linked Schedules</dt>
+    <dd class="col-sm-9">{{ schedule_count }}</dd>
+  </dl>
+
+  {% if milestones %}
+  <h4 class="mt-4">Milestone Schedule</h4>
+  <table class="table table-sm table-bordered">
+    <thead class="table-light">
+      <tr><th>Milestone</th><th>Trigger</th><th>Percentage</th></tr>
+    </thead>
+    <tbody>
+      {% for m in milestones %}
+      <tr>
+        <td>{{ m.name|default:forloop.counter }}</td>
+        <td>{{ m.trigger|default:"—" }}</td>
+        <td>{{ m.percentage }}%</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <h4 class="mt-4">Configuration</h4>
+  <pre class="bg-light p-3 rounded"><code>{{ payment_rule.config_json }}</code></pre>
+  {% endif %}
+</div>
+{% endblock %}

--- a/src/apps/ui/templates/payment_rules/list.html
+++ b/src/apps/ui/templates/payment_rules/list.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% block title %}Payment Rules{% endblock %}
+{% block content %}
+<div class="container mt-4">
+  <h2>Payment Rules</h2>
+  <p class="text-muted">Payment rules are managed by administrators and are immutable once linked to a funding schedule.</p>
+
+  {% if payment_rules %}
+  <table class="table table-hover">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Type</th>
+        <th>Version</th>
+        <th>Active</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for rule in payment_rules %}
+      <tr>
+        <td>{{ rule.name }}</td>
+        <td>{{ rule.get_rule_type_display }}</td>
+        <td>v{{ rule.version }}</td>
+        <td>{% if rule.is_active %}<span class="badge bg-success">Active</span>{% else %}<span class="badge bg-secondary">Inactive</span>{% endif %}</td>
+        <td>
+          <a href="{% url 'ui:payment_rule_detail' pk=rule.pk %}" class="btn btn-sm btn-outline-secondary">View</a>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="text-muted">No payment rules configured.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/src/apps/ui/templates/works/detail.html
+++ b/src/apps/ui/templates/works/detail.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+{% block title %}Work Item{% endblock %}
+{% block content %}
+<div class="container mt-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2>{{ work }}</h2>
+    <div>
+      <a href="{% url 'ui:work_edit' project_pk=work.project_id pk=work.pk %}" class="btn btn-outline-primary">Edit</a>
+      <a href="{% url 'ui:work_delete' project_pk=work.project_id pk=work.pk %}" class="btn btn-outline-danger">Delete</a>
+      <a href="{% url 'ui:work_list' project_pk=work.project_id %}" class="btn btn-outline-secondary">Back</a>
+    </div>
+  </div>
+
+  <dl class="row">
+    <dt class="col-sm-3">Project</dt>
+    <dd class="col-sm-9">{{ work.project.name }}</dd>
+
+    <dt class="col-sm-3">Work Type</dt>
+    <dd class="col-sm-9">{{ work.work_type|default:work.work_type_other|default:"—" }}</dd>
+
+    <dt class="col-sm-3">Bedrooms</dt>
+    <dd class="col-sm-9">{% if work.bedrooms %}{{ work.bedrooms }}BR{% else %}—{% endif %}</dd>
+
+    <dt class="col-sm-3">Quantity</dt>
+    <dd class="col-sm-9">{{ work.quantity }}</dd>
+
+    <dt class="col-sm-3">Estimated Cost (unit)</dt>
+    <dd class="col-sm-9">${{ work.estimated_cost|floatformat:2 }}</dd>
+
+    <dt class="col-sm-3">Total Estimated Cost</dt>
+    <dd class="col-sm-9">${{ work.total_estimated_cost|floatformat:2 }}</dd>
+
+    <dt class="col-sm-3">Cost Source</dt>
+    <dd class="col-sm-9">{{ work.cost_source }}</dd>
+
+    {% if work.actual_cost %}
+    <dt class="col-sm-3">Actual Cost</dt>
+    <dd class="col-sm-9">${{ work.actual_cost|floatformat:2 }}</dd>
+    {% endif %}
+
+    <dt class="col-sm-3">Status</dt>
+    <dd class="col-sm-9">{{ work.get_status_display }}</dd>
+
+    <dt class="col-sm-3">Address</dt>
+    <dd class="col-sm-9">{{ work.address|default:"—" }}</dd>
+  </dl>
+</div>
+{% endblock %}

--- a/src/apps/ui/templates/works/list.html
+++ b/src/apps/ui/templates/works/list.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+{% block title %}Works — {{ project.name }}{% endblock %}
+{% block content %}
+<div class="container mt-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2>Works</h2>
+    <a href="{% url 'ui:work_create' project_pk=project.pk %}" class="btn btn-primary">+ Add Work</a>
+  </div>
+  <p class="text-muted">Project: <strong>{{ project.name }}</strong></p>
+
+  {% if works %}
+  <table class="table table-hover">
+    <thead>
+      <tr>
+        <th>Work Type</th>
+        <th>Bedrooms</th>
+        <th>Qty</th>
+        <th>Est. Cost</th>
+        <th>Status</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for work in works %}
+      <tr>
+        <td>{{ work.work_type|default:work.work_type_other }}</td>
+        <td>{% if work.bedrooms %}{{ work.bedrooms }}BR{% else %}—{% endif %}</td>
+        <td>{{ work.quantity }}</td>
+        <td>${{ work.total_estimated_cost|floatformat:0 }}</td>
+        <td>{{ work.get_status_display }}</td>
+        <td>
+          <a href="{% url 'ui:work_detail' project_pk=project.pk pk=work.pk %}" class="btn btn-sm btn-outline-secondary">View</a>
+          <a href="{% url 'ui:work_edit' project_pk=project.pk pk=work.pk %}" class="btn btn-sm btn-outline-primary">Edit</a>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="text-muted">No work items yet.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/src/apps/ui/urls.py
+++ b/src/apps/ui/urls.py
@@ -123,6 +123,30 @@ urlpatterns = [
     path('development-applications/<int:pk>/edit/', views.land_crud_views.DevelopmentApplicationUpdateView.as_view(), name='development_application_edit'),
     path('development-applications/<int:pk>/delete/', views.land_crud_views.DevelopmentApplicationDeleteView.as_view(), name='development_application_delete'),
 
+    # PaymentRule (read-only — issue #19)
+    path('payment-rules/', views.crud_views.PaymentRuleListView.as_view(), name='payment_rule_list'),
+    path('payment-rules/<int:pk>/', views.crud_views.PaymentRuleDetailView.as_view(), name='payment_rule_detail'),
+
+    # Approvals (issue #15)
+    path('approvals/', views.crud_views.ApprovalListView.as_view(), name='approval_list'),
+    path('approvals/<int:pk>/', views.crud_views.ApprovalDetailView.as_view(), name='approval_detail'),
+    path('approvals/<int:pk>/approve/', views.crud_views.ApprovalApproveView.as_view(), name='approval_approve'),
+    path('approvals/<int:pk>/reject/', views.crud_views.ApprovalRejectView.as_view(), name='approval_reject'),
+
+    # Works (nested under project — issue #18)
+    path('projects/<int:project_pk>/works/', views.crud_views.WorkListView.as_view(), name='work_list'),
+    path('projects/<int:project_pk>/works/create/', views.crud_views.WorkCreateView.as_view(), name='work_create'),
+    path('projects/<int:project_pk>/works/<int:pk>/', views.crud_views.WorkDetailView.as_view(), name='work_detail'),
+    path('projects/<int:project_pk>/works/<int:pk>/edit/', views.crud_views.WorkUpdateView.as_view(), name='work_edit'),
+    path('projects/<int:project_pk>/works/<int:pk>/delete/', views.crud_views.WorkDeleteView.as_view(), name='work_delete'),
+
+    # Addresses (nested under project — issue #18)
+    path('projects/<int:project_pk>/addresses/', views.crud_views.AddressListView.as_view(), name='address_list'),
+    path('projects/<int:project_pk>/addresses/create/', views.crud_views.AddressCreateView.as_view(), name='address_create'),
+    path('projects/<int:project_pk>/addresses/<int:pk>/', views.crud_views.AddressDetailView.as_view(), name='address_detail'),
+    path('projects/<int:project_pk>/addresses/<int:pk>/edit/', views.crud_views.AddressUpdateView.as_view(), name='address_edit'),
+    path('projects/<int:project_pk>/addresses/<int:pk>/delete/', views.crud_views.AddressDeleteView.as_view(), name='address_delete'),
+
     # Other existing views
     path('reports/', views.reports_views.reports_dashboard_view, name='reports_dashboard'),
     path('land-infra/', views.land_infra_views.land_projects_list_view, name='land_projects_list'),

--- a/src/apps/ui/views/crud_views.py
+++ b/src/apps/ui/views/crud_views.py
@@ -14,8 +14,8 @@ from django.shortcuts import get_object_or_404, redirect
 from django.utils import timezone
 
 from apps.core.models import (
-    BriefFinancialApproval, Council, DevelopmentApplication, LandTenure,
-    Program, Project, WorkType, FundingSchedule,
+    Approval, Address, BriefFinancialApproval, Council, DevelopmentApplication, LandTenure,
+    PaymentRule, Program, Project, Work, WorkType, FundingSchedule,
     Variation, Payment, StageReport, QuarterlyReport,
     FundingAgreement, FundingNotice, ExpenseClaim,
 )
@@ -886,3 +886,246 @@ class BriefFinancialApprovalRejectView(LoginRequiredMixin, View):
         bfa.save()
         messages.success(request, 'Brief Financial Approval rejected.')
         return redirect('ui:bfa_detail', project_pk=project_pk, pk=pk)
+
+
+# ---------------------------------------------------------------------------
+# PaymentRule (issue #19 — read-only; admin-create only)
+# ---------------------------------------------------------------------------
+
+class PaymentRuleListView(LoginRequiredMixin, ListView):
+    model = PaymentRule
+    template_name = 'payment_rules/list.html'
+    context_object_name = 'payment_rules'
+    paginate_by = 50
+
+    def get_queryset(self):
+        return PaymentRule.objects.order_by('name', '-version')
+
+
+class PaymentRuleDetailView(LoginRequiredMixin, DetailView):
+    model = PaymentRule
+    template_name = 'payment_rules/detail.html'
+    context_object_name = 'payment_rule'
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        rule = self.object
+        ctx['schedule_count'] = FundingSchedule.objects.filter(payment_rule=rule).count()
+        milestones = []
+        if rule.rule_type == PaymentRule.RuleType.SPLIT:
+            milestones = rule.config_json.get('milestones', [])
+        ctx['milestones'] = milestones
+        return ctx
+
+
+# ---------------------------------------------------------------------------
+# Approval (issue #15 — system-generated; approve/reject from UI)
+# ---------------------------------------------------------------------------
+
+class ApprovalListView(LoginRequiredMixin, ListView):
+    model = Approval
+    template_name = 'approvals/list.html'
+    context_object_name = 'approvals'
+    paginate_by = 50
+
+    def get_queryset(self):
+        qs = Approval.objects.select_related('approved_by').order_by('-created_at')
+        status = self.request.GET.get('status', '')
+        approval_type = self.request.GET.get('type', '')
+        if status:
+            qs = qs.filter(status=status)
+        if approval_type:
+            qs = qs.filter(approval_type=approval_type)
+        return qs
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['approval_types'] = Approval.ApprovalType.choices
+        ctx['status_choices'] = Approval.Status.choices
+        ctx['selected_status'] = self.request.GET.get('status', '')
+        ctx['selected_type'] = self.request.GET.get('type', '')
+        return ctx
+
+
+class ApprovalDetailView(LoginRequiredMixin, DetailView):
+    model = Approval
+    template_name = 'approvals/detail.html'
+    context_object_name = 'approval'
+
+
+class ApprovalApproveView(LoginRequiredMixin, View):
+    def post(self, request, pk):
+        approval = get_object_or_404(Approval, pk=pk)
+        if approval.status != Approval.Status.PENDING:
+            messages.error(request, 'Only pending approvals can be approved.')
+            return redirect('ui:approval_detail', pk=pk)
+        approval.status = Approval.Status.APPROVED
+        approval.approved_by = request.user
+        approval.approved_at = timezone.now()
+        approval.save()
+        messages.success(request, 'Approval granted.')
+        return redirect('ui:approval_detail', pk=pk)
+
+
+class ApprovalRejectView(LoginRequiredMixin, View):
+    def post(self, request, pk):
+        approval = get_object_or_404(Approval, pk=pk)
+        if approval.status != Approval.Status.PENDING:
+            messages.error(request, 'Only pending approvals can be rejected.')
+            return redirect('ui:approval_detail', pk=pk)
+        approval.status = Approval.Status.REJECTED
+        approval.save()
+        messages.success(request, 'Approval rejected.')
+        return redirect('ui:approval_detail', pk=pk)
+
+
+# ---------------------------------------------------------------------------
+# Work (issue #18 — nested under project)
+# ---------------------------------------------------------------------------
+
+class WorkListView(LoginRequiredMixin, ListView):
+    model = Work
+    template_name = 'works/list.html'
+    context_object_name = 'works'
+
+    def get_queryset(self):
+        return Work.objects.filter(
+            project_id=self.kwargs['project_pk']
+        ).select_related('work_type', 'address').order_by('created_at')
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['project'] = get_object_or_404(Project, pk=self.kwargs['project_pk'])
+        return ctx
+
+
+class WorkCreateView(LoginRequiredMixin, CreateView):
+    model = Work
+    template_name = 'crud/form.html'
+    fields = ['work_type', 'work_type_other', 'bedrooms', 'quantity',
+              'estimated_cost', 'status', 'is_notional_cost', 'actual_cost', 'address']
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        if kwargs.get('instance') is None:
+            kwargs['instance'] = Work(project_id=self.kwargs['project_pk'])
+        return kwargs
+
+    def get_success_url(self):
+        return reverse_lazy('ui:work_list', kwargs={'project_pk': self.kwargs['project_pk']})
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['title'] = 'Add Work Item'
+        ctx['back_url'] = reverse_lazy('ui:work_list', kwargs={'project_pk': self.kwargs['project_pk']})
+        return ctx
+
+
+class WorkDetailView(LoginRequiredMixin, DetailView):
+    model = Work
+    template_name = 'works/detail.html'
+    context_object_name = 'work'
+
+
+class WorkUpdateView(LoginRequiredMixin, UpdateView):
+    model = Work
+    template_name = 'crud/form.html'
+    fields = ['work_type', 'work_type_other', 'bedrooms', 'quantity',
+              'estimated_cost', 'status', 'is_notional_cost', 'actual_cost', 'address']
+
+    def get_success_url(self):
+        return reverse_lazy('ui:work_list', kwargs={'project_pk': self.object.project_id})
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['title'] = f'Edit Work: {self.object}'
+        ctx['back_url'] = reverse_lazy('ui:work_list', kwargs={'project_pk': self.object.project_id})
+        return ctx
+
+
+class WorkDeleteView(LoginRequiredMixin, DeleteView):
+    model = Work
+    template_name = 'crud/confirm_delete.html'
+
+    def get_success_url(self):
+        return reverse_lazy('ui:work_list', kwargs={'project_pk': self.object.project_id})
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['back_url'] = reverse_lazy('ui:work_list', kwargs={'project_pk': self.object.project_id})
+        return ctx
+
+
+# ---------------------------------------------------------------------------
+# Address (issue #18 — nested under project)
+# ---------------------------------------------------------------------------
+
+class AddressListView(LoginRequiredMixin, ListView):
+    model = Address
+    template_name = 'addresses/list.html'
+    context_object_name = 'addresses'
+
+    def get_queryset(self):
+        return Address.objects.filter(
+            project_id=self.kwargs['project_pk']
+        ).select_related('suburb').order_by('street')
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['project'] = get_object_or_404(Project, pk=self.kwargs['project_pk'])
+        return ctx
+
+
+class AddressCreateView(LoginRequiredMixin, CreateView):
+    model = Address
+    template_name = 'crud/form.html'
+    fields = ['street', 'suburb', 'lot', 'plan', 'residence_plc_ref']
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        if kwargs.get('instance') is None:
+            kwargs['instance'] = Address(project_id=self.kwargs['project_pk'])
+        return kwargs
+
+    def get_success_url(self):
+        return reverse_lazy('ui:address_list', kwargs={'project_pk': self.kwargs['project_pk']})
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['title'] = 'Add Address'
+        ctx['back_url'] = reverse_lazy('ui:address_list', kwargs={'project_pk': self.kwargs['project_pk']})
+        return ctx
+
+
+class AddressDetailView(LoginRequiredMixin, DetailView):
+    model = Address
+    template_name = 'addresses/detail.html'
+    context_object_name = 'address'
+
+
+class AddressUpdateView(LoginRequiredMixin, UpdateView):
+    model = Address
+    template_name = 'crud/form.html'
+    fields = ['street', 'suburb', 'lot', 'plan', 'residence_plc_ref']
+
+    def get_success_url(self):
+        return reverse_lazy('ui:address_list', kwargs={'project_pk': self.object.project_id})
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['title'] = f'Edit Address: {self.object}'
+        ctx['back_url'] = reverse_lazy('ui:address_list', kwargs={'project_pk': self.object.project_id})
+        return ctx
+
+
+class AddressDeleteView(LoginRequiredMixin, DeleteView):
+    model = Address
+    template_name = 'crud/confirm_delete.html'
+
+    def get_success_url(self):
+        return reverse_lazy('ui:address_list', kwargs={'project_pk': self.object.project_id})
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['back_url'] = reverse_lazy('ui:address_list', kwargs={'project_pk': self.object.project_id})
+        return ctx

--- a/tests/test_issue_15_18_19.py
+++ b/tests/test_issue_15_18_19.py
@@ -1,0 +1,347 @@
+"""
+Tests for issues #15 (Approval CRUD), #18 (Work & Address CRUD), #19 (PaymentRule read-only).
+"""
+import pytest
+from decimal import Decimal
+from django.test import Client
+from django.contrib.auth.models import User
+from apps.core.models import Approval, Address, PaymentRule, Work, Profile
+
+
+@pytest.fixture
+def auth_client(council):
+    client = Client()
+    user = User.objects.create_user(username='crud_user', password='pass')
+    Profile.objects.create(user=user, council=council, officer_role=Profile.OfficerRole.SENIOR_OFFICER)
+    client.force_login(user)
+    return client, user
+
+
+@pytest.fixture
+def payment_rule():
+    return PaymentRule.objects.create(
+        name='Test SPLIT Rule',
+        rule_type=PaymentRule.RuleType.SPLIT,
+        config_json={'milestones': [
+            {'name': 'Stage 1', 'trigger': 'Report approved', 'percentage': 60},
+            {'name': 'Stage 2', 'trigger': 'Completion', 'percentage': 40},
+        ]},
+        version=1,
+    )
+
+
+@pytest.fixture
+def approval():
+    return Approval.objects.create(
+        entity_type='Project',
+        entity_id=1,
+        approval_type=Approval.ApprovalType.PAYMENT,
+        required_role=Approval.RequiredRole.MANAGER,
+        status=Approval.Status.PENDING,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #19: PaymentRule (read-only)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestPaymentRuleList:
+    def test_list_get(self, auth_client, payment_rule):
+        client, _ = auth_client
+        response = client.get('/payment-rules/')
+        assert response.status_code == 200
+
+    def test_list_shows_rule(self, auth_client, payment_rule):
+        client, _ = auth_client
+        response = client.get('/payment-rules/')
+        assert b'Test SPLIT Rule' in response.content
+
+    def test_list_requires_login(self):
+        response = Client().get('/payment-rules/')
+        assert response.status_code == 302
+
+
+@pytest.mark.django_db
+class TestPaymentRuleDetail:
+    def test_detail_get(self, auth_client, payment_rule):
+        client, _ = auth_client
+        response = client.get(f'/payment-rules/{payment_rule.pk}/')
+        assert response.status_code == 200
+
+    def test_detail_shows_milestones(self, auth_client, payment_rule):
+        client, _ = auth_client
+        response = client.get(f'/payment-rules/{payment_rule.pk}/')
+        assert b'Stage 1' in response.content
+        assert b'60' in response.content
+
+    def test_detail_404_on_missing(self, auth_client):
+        client, _ = auth_client
+        response = client.get('/payment-rules/99999/')
+        assert response.status_code == 404
+
+    def test_detail_requires_login(self, payment_rule):
+        response = Client().get(f'/payment-rules/{payment_rule.pk}/')
+        assert response.status_code == 302
+
+
+# ---------------------------------------------------------------------------
+# Issue #15: Approval
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestApprovalList:
+    def test_list_get(self, auth_client, approval):
+        client, _ = auth_client
+        response = client.get('/approvals/')
+        assert response.status_code == 200
+
+    def test_list_shows_approval(self, auth_client, approval):
+        client, _ = auth_client
+        response = client.get('/approvals/')
+        assert response.status_code == 200
+
+    def test_list_filter_by_status(self, auth_client, approval):
+        client, _ = auth_client
+        response = client.get('/approvals/?status=PENDING')
+        assert response.status_code == 200
+
+    def test_list_requires_login(self):
+        response = Client().get('/approvals/')
+        assert response.status_code == 302
+
+
+@pytest.mark.django_db
+class TestApprovalDetail:
+    def test_detail_get(self, auth_client, approval):
+        client, _ = auth_client
+        response = client.get(f'/approvals/{approval.pk}/')
+        assert response.status_code == 200
+
+    def test_detail_shows_approve_button_when_pending(self, auth_client, approval):
+        client, _ = auth_client
+        response = client.get(f'/approvals/{approval.pk}/')
+        assert b'Approve' in response.content
+
+    def test_detail_404_on_missing(self, auth_client):
+        client, _ = auth_client
+        response = client.get('/approvals/99999/')
+        assert response.status_code == 404
+
+
+@pytest.mark.django_db
+class TestApprovalApproveReject:
+    def test_approve_sets_status(self, auth_client, approval):
+        client, user = auth_client
+        response = client.post(f'/approvals/{approval.pk}/approve/', follow=True)
+        assert response.status_code == 200
+        approval.refresh_from_db()
+        assert approval.status == Approval.Status.APPROVED
+        assert approval.approved_by == user
+        assert approval.approved_at is not None
+
+    def test_reject_sets_status(self, auth_client, approval):
+        client, _ = auth_client
+        client.post(f'/approvals/{approval.pk}/reject/')
+        approval.refresh_from_db()
+        assert approval.status == Approval.Status.REJECTED
+
+    def test_cannot_approve_already_approved(self, auth_client, approval):
+        client, user = auth_client
+        approval.status = Approval.Status.APPROVED
+        approval.approved_by = user
+        approval.save()
+        client.post(f'/approvals/{approval.pk}/approve/')
+        approval.refresh_from_db()
+        assert approval.status == Approval.Status.APPROVED
+
+    def test_approve_requires_post(self, auth_client, approval):
+        client, _ = auth_client
+        response = client.get(f'/approvals/{approval.pk}/approve/')
+        assert response.status_code == 405
+
+    def test_reject_requires_post(self, auth_client, approval):
+        client, _ = auth_client
+        response = client.get(f'/approvals/{approval.pk}/reject/')
+        assert response.status_code == 405
+
+
+# ---------------------------------------------------------------------------
+# Issue #18: Work
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestWorkList:
+    def test_list_get(self, auth_client, project):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/works/')
+        assert response.status_code == 200
+
+    def test_list_shows_work(self, auth_client, project, work):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/works/')
+        assert response.status_code == 200
+
+    def test_list_requires_login(self, project):
+        response = Client().get(f'/projects/{project.pk}/works/')
+        assert response.status_code == 302
+
+
+@pytest.mark.django_db
+class TestWorkCreate:
+    def test_create_get(self, auth_client, project):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/works/create/')
+        assert response.status_code == 200
+
+    def test_create_post_creates_object(self, auth_client, project, work_type):
+        client, _ = auth_client
+        response = client.post(f'/projects/{project.pk}/works/create/', {
+            'work_type': work_type.pk,
+            'quantity': 1,
+            'estimated_cost': '250000',
+            'status': 'PENDING',
+            'bedrooms': 0,
+            'is_notional_cost': True,
+        }, follow=True)
+        assert response.status_code == 200
+        assert Work.objects.filter(project=project, work_type=work_type).exists()
+
+    def test_create_requires_login(self, project):
+        response = Client().get(f'/projects/{project.pk}/works/create/')
+        assert response.status_code == 302
+
+
+@pytest.mark.django_db
+class TestWorkDetail:
+    def test_detail_get(self, auth_client, project, work):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/works/{work.pk}/')
+        assert response.status_code == 200
+
+    def test_detail_404_on_missing(self, auth_client, project):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/works/99999/')
+        assert response.status_code == 404
+
+
+@pytest.mark.django_db
+class TestWorkEdit:
+    def test_edit_get(self, auth_client, project, work):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/works/{work.pk}/edit/')
+        assert response.status_code == 200
+
+    def test_edit_post_updates_object(self, auth_client, project, work, work_type):
+        client, _ = auth_client
+        client.post(f'/projects/{project.pk}/works/{work.pk}/edit/', {
+            'work_type': work_type.pk,
+            'quantity': 2,
+            'estimated_cost': '300000',
+            'status': 'IN_PROGRESS',
+            'bedrooms': 0,
+            'is_notional_cost': True,
+        })
+        work.refresh_from_db()
+        assert work.quantity == 2
+        assert work.status == 'IN_PROGRESS'
+
+
+@pytest.mark.django_db
+class TestWorkDelete:
+    def test_delete_get(self, auth_client, project, work):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/works/{work.pk}/delete/')
+        assert response.status_code == 200
+
+    def test_delete_post_removes_object(self, auth_client, project, work):
+        client, _ = auth_client
+        work_id = work.pk
+        client.post(f'/projects/{project.pk}/works/{work_id}/delete/')
+        assert not Work.objects.filter(pk=work_id).exists()
+
+
+# ---------------------------------------------------------------------------
+# Issue #18: Address
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestAddressList:
+    def test_list_get(self, auth_client, project):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/addresses/')
+        assert response.status_code == 200
+
+    def test_list_shows_address(self, auth_client, project, address):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/addresses/')
+        assert response.status_code == 200
+
+    def test_list_requires_login(self, project):
+        response = Client().get(f'/projects/{project.pk}/addresses/')
+        assert response.status_code == 302
+
+
+@pytest.mark.django_db
+class TestAddressCreate:
+    def test_create_get(self, auth_client, project):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/addresses/create/')
+        assert response.status_code == 200
+
+    def test_create_post_creates_object(self, auth_client, project):
+        client, _ = auth_client
+        response = client.post(f'/projects/{project.pk}/addresses/create/', {
+            'street': '123 Test Street',
+            'lot': '1',
+            'plan': 'SP123',
+        }, follow=True)
+        assert response.status_code == 200
+        assert Address.objects.filter(project=project, street='123 Test Street').exists()
+
+    def test_create_requires_login(self, project):
+        response = Client().get(f'/projects/{project.pk}/addresses/create/')
+        assert response.status_code == 302
+
+
+@pytest.mark.django_db
+class TestAddressDetail:
+    def test_detail_get(self, auth_client, project, address):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/addresses/{address.pk}/')
+        assert response.status_code == 200
+
+    def test_detail_404_on_missing(self, auth_client, project):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/addresses/99999/')
+        assert response.status_code == 404
+
+
+@pytest.mark.django_db
+class TestAddressEdit:
+    def test_edit_get(self, auth_client, project, address):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/addresses/{address.pk}/edit/')
+        assert response.status_code == 200
+
+    def test_edit_post_updates_object(self, auth_client, project, address):
+        client, _ = auth_client
+        client.post(f'/projects/{project.pk}/addresses/{address.pk}/edit/', {
+            'street': '456 New Street',
+        })
+        address.refresh_from_db()
+        assert address.street == '456 New Street'
+
+
+@pytest.mark.django_db
+class TestAddressDelete:
+    def test_delete_get(self, auth_client, project, address):
+        client, _ = auth_client
+        response = client.get(f'/projects/{project.pk}/addresses/{address.pk}/delete/')
+        assert response.status_code == 200
+
+    def test_delete_post_removes_object(self, auth_client, project, address):
+        client, _ = auth_client
+        addr_id = address.pk
+        client.post(f'/projects/{project.pk}/addresses/{addr_id}/delete/')
+        assert not Address.objects.filter(pk=addr_id).exists()


### PR DESCRIPTION
## Summary

Closes #15, #18, #19

**#19 — PaymentRule (read-only)**
- List + detail at `/payment-rules/`
- Detail renders SPLIT milestones as a readable table
- Immutability warning when rule is linked to a funding schedule

**#15 — Approval governance**
- List with status/type filters at `/approvals/`
- Detail with Approve/Reject buttons (PENDING only, guard against double-transition)

**#18 — Work & Address**
- Work CRUD at `/projects/<pk>/works/` (nested under project)
- Address CRUD at `/projects/<pk>/addresses/` (nested under project)

## Test plan
- [ ] CI passes
- [ ] `/payment-rules/` list and detail load correctly
- [ ] `/approvals/` approve and reject actions work
- [ ] Work and Address create/edit/delete work under a project
- [ ] All unauthenticated requests redirect to login

43 new tests, 347 total passing locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)