### PR TITLE
feat: VariationItem CRUD, WorkFunding allocation CRUD, StageReport li…

### DIFF
--- a/src/apps/core/models/__init__.py
+++ b/src/apps/core/models/__init__.py
@@ -32,7 +32,10 @@ from .funding_models import (
 from .payments_models import Payment
 
 # Variation & Stage models
-from .variations_models import VariationType, Variation, VariationFundingSchedule, VariationContactDetails, VariationDateChange
+from .variations_models import (
+    VariationType, Variation, VariationItem, VariationFundingSchedule,
+    VariationContactDetails, VariationDateChange,
+)
 from .stages_models import Stage, WorkStep
 
 # Report models
@@ -79,7 +82,7 @@ __all__ = [
     'FundingSchedule', 'ProjectStateLog', 'WorkFunding',
     'Approval', 'WorkflowAction', 'AuditLog', 'Payment',
     # Variation & Stage
-    'VariationType', 'Variation', 'VariationFundingSchedule',
+    'VariationType', 'Variation', 'VariationItem', 'VariationFundingSchedule',
     'VariationContactDetails', 'VariationDateChange',
     'Stage', 'WorkStep',
     # Report

--- a/src/apps/ui/templates/allocations/detail.html
+++ b/src/apps/ui/templates/allocations/detail.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block title %}Allocation #{{ allocation.pk }} - RICD{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h2>Allocation #{{ allocation.pk }}</h2>
+  <div class="d-flex gap-2">
+    <a href="{% url 'ui:allocation_edit' allocation.pk %}" class="btn btn-secondary">Edit</a>
+    <a href="{% url 'ui:allocation_delete' allocation.pk %}" class="btn btn-outline-danger">Delete</a>
+    <a href="{% url 'ui:allocation_list' %}" class="btn btn-outline-secondary">Back</a>
+  </div>
+</div>
+<div class="card"><div class="card-body">
+  <dl class="row">
+    <dt class="col-sm-3">Funding Schedule</dt><dd class="col-sm-9">{{ allocation.funding_schedule }}</dd>
+    <dt class="col-sm-3">Project</dt><dd class="col-sm-9">{{ allocation.project|default:"-" }}</dd>
+    <dt class="col-sm-3">Work</dt><dd class="col-sm-9">{{ allocation.work|default:"-" }}</dd>
+    <dt class="col-sm-3">Cost Centre</dt><dd class="col-sm-9">{{ allocation.cost_centre|default:"-" }}</dd>
+    <dt class="col-sm-3">GL Code</dt><dd class="col-sm-9">{{ allocation.gl_code|default:"-" }}</dd>
+    <dt class="col-sm-3">Tax Code</dt><dd class="col-sm-9">{{ allocation.tax_code|default:"-" }}</dd>
+    <dt class="col-sm-3">Amount</dt><dd class="col-sm-9">{% if allocation.amount %}${{ allocation.amount }}{% else %}-{% endif %}</dd>
+    <dt class="col-sm-3">Notes</dt><dd class="col-sm-9">{{ allocation.notes|default:"-" }}</dd>
+  </dl>
+</div></div>
+{% endblock %}

--- a/src/apps/ui/templates/allocations/list.html
+++ b/src/apps/ui/templates/allocations/list.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+{% block title %}Allocations - RICD{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h2>Allocations</h2>
+  <a href="{% url 'ui:allocation_create' %}" class="btn btn-primary">New Allocation</a>
+</div>
+<div class="table-responsive">
+  <table class="table table-sm table-hover">
+    <thead><tr><th>Funding Schedule</th><th>Project</th><th>Work</th><th>Cost Centre</th><th>Amount</th><th></th></tr></thead>
+    <tbody>
+    {% for a in allocations %}
+      <tr>
+        <td>{{ a.funding_schedule }}</td>
+        <td>{{ a.project|default:"-" }}</td>
+        <td>{{ a.work|default:"-" }}</td>
+        <td>{{ a.cost_centre|default:"-" }}</td>
+        <td>{% if a.amount %}${{ a.amount }}{% else %}-{% endif %}</td>
+        <td>
+          <a href="{% url 'ui:allocation_detail' a.pk %}" class="btn btn-sm btn-outline-secondary">View</a>
+          <a href="{% url 'ui:allocation_edit' a.pk %}" class="btn btn-sm btn-outline-secondary">Edit</a>
+          <a href="{% url 'ui:allocation_delete' a.pk %}" class="btn btn-sm btn-outline-danger">Delete</a>
+        </td>
+      </tr>
+    {% empty %}
+      <tr><td colspan="6" class="text-muted">No allocations found.</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% if is_paginated %}
+<nav><ul class="pagination">
+  {% if page_obj.has_previous %}<li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}">Previous</a></li>{% endif %}
+  <li class="page-item disabled"><span class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span></li>
+  {% if page_obj.has_next %}<li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}">Next</a></li>{% endif %}
+</ul></nav>
+{% endif %}
+{% endblock %}

--- a/src/apps/ui/templates/stage_reports/detail.html
+++ b/src/apps/ui/templates/stage_reports/detail.html
@@ -2,9 +2,26 @@
 {% block title %}Stage Report #{{ stage_report.pk }} - RICD{% endblock %}
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-3">
-  <h2>Stage Report - {{ stage_report.get_stage_type_display }}</h2>
+  <h2>{{ stage_report.get_stage_type_display }} Report — {{ stage_report.project }}</h2>
   <div class="d-flex gap-2">
-    <a href="{% url 'ui:stage_report_edit' stage_report.project_id stage_report.pk %}" class="btn btn-secondary">Edit</a>
+    {% if stage_report.status == 'DRAFT' %}
+      <a href="{% url 'ui:stage_report_edit' stage_report.project_id stage_report.pk %}" class="btn btn-secondary">Edit</a>
+      <form method="post" action="{% url 'ui:stage_report_submit' stage_report.project_id stage_report.pk %}">
+        {% csrf_token %}<button class="btn btn-primary">Submit</button>
+      </form>
+    {% elif stage_report.status == 'SUBMITTED' %}
+      <form method="post" action="{% url 'ui:stage_report_endorse' stage_report.project_id stage_report.pk %}">
+        {% csrf_token %}<button class="btn btn-success">Endorse</button>
+      </form>
+    {% elif stage_report.status == 'ENDORSED' %}
+      <form method="post" action="{% url 'ui:stage_report_assess' stage_report.project_id stage_report.pk %}">
+        {% csrf_token %}<button class="btn btn-info">Assess</button>
+      </form>
+    {% elif stage_report.status == 'ASSESSED' %}
+      <form method="post" action="{% url 'ui:stage_report_approve' stage_report.project_id stage_report.pk %}">
+        {% csrf_token %}<button class="btn btn-success">Approve</button>
+      </form>
+    {% endif %}
     <a href="{% url 'ui:stage_report_list' stage_report.project_id %}" class="btn btn-outline-secondary">Back</a>
   </div>
 </div>
@@ -13,6 +30,11 @@
     <dt class="col-sm-3">Project</dt><dd class="col-sm-9">{{ stage_report.project }}</dd>
     <dt class="col-sm-3">Stage</dt><dd class="col-sm-9">{{ stage_report.get_stage_type_display }}</dd>
     <dt class="col-sm-3">Status</dt><dd class="col-sm-9">{{ stage_report.get_status_display }}</dd>
+    <dt class="col-sm-3">Funding Schedule</dt><dd class="col-sm-9">{{ stage_report.funding_schedule|default:"-" }}</dd>
+    <dt class="col-sm-3">Submitted by</dt><dd class="col-sm-9">{{ stage_report.submitted_by|default:"-" }}</dd>
+    <dt class="col-sm-3">Endorsed by</dt><dd class="col-sm-9">{{ stage_report.endorsed_by|default:"-" }}</dd>
+    <dt class="col-sm-3">Assessed by</dt><dd class="col-sm-9">{{ stage_report.assessed_by|default:"-" }}</dd>
+    <dt class="col-sm-3">Approved by</dt><dd class="col-sm-9">{{ stage_report.approved_by|default:"-" }}</dd>
     <dt class="col-sm-3">Notes</dt><dd class="col-sm-9">{{ stage_report.notes|default:"-" }}</dd>
   </dl>
 </div></div>

--- a/src/apps/ui/templates/variations/detail.html
+++ b/src/apps/ui/templates/variations/detail.html
@@ -4,11 +4,16 @@
 <div class="d-flex justify-content-between align-items-center mb-3">
   <h2>Variation #{{ variation.pk }}</h2>
   <div class="d-flex gap-2">
-    <a href="{% url 'ui:variation_edit' variation.pk %}" class="btn btn-secondary">Edit</a>
+    {% if variation.status == 'DRAFT' or variation.status == 'COUNCIL_SIGNED' %}
+      <a href="{% url 'ui:variation_edit' variation.pk %}" class="btn btn-secondary">Edit</a>
+      <form method="post" action="{% url 'ui:variation_execute' variation.pk %}">
+        {% csrf_token %}<button class="btn btn-success">Execute</button>
+      </form>
+    {% endif %}
     <a href="{% url 'ui:variations_list' %}" class="btn btn-outline-secondary">Back</a>
   </div>
 </div>
-<div class="card"><div class="card-body">
+<div class="card mb-3"><div class="card-body">
   <dl class="row">
     <dt class="col-sm-3">Funding Schedule</dt><dd class="col-sm-9">{{ variation.funding_schedule|default:"-" }}</dd>
     <dt class="col-sm-3">Option</dt><dd class="col-sm-9">{{ variation.get_variation_option_display|default:"-" }}</dd>
@@ -16,4 +21,32 @@
     <dt class="col-sm-3">Description</dt><dd class="col-sm-9">{{ variation.description|default:"-" }}</dd>
   </dl>
 </div></div>
+
+<div class="d-flex justify-content-between align-items-center mb-2">
+  <h5>Items</h5>
+  {% if variation.status == 'DRAFT' %}
+    <a href="{% url 'ui:variation_item_create' variation.pk %}" class="btn btn-sm btn-outline-primary">Add Item</a>
+  {% endif %}
+</div>
+<div class="table-responsive">
+  <table class="table table-sm">
+    <thead><tr><th>Option</th><th>Description</th><th>Actions</th></tr></thead>
+    <tbody>
+    {% for item in variation.items.all %}
+      <tr>
+        <td>{{ item.get_option_display }}</td>
+        <td>{{ item.description|default:"-"|truncatechars:60 }}</td>
+        <td>
+          {% if variation.status == 'DRAFT' %}
+            <a href="{% url 'ui:variation_item_edit' variation.pk item.pk %}" class="btn btn-xs btn-outline-secondary btn-sm">Edit</a>
+            <a href="{% url 'ui:variation_item_delete' variation.pk item.pk %}" class="btn btn-xs btn-outline-danger btn-sm">Delete</a>
+          {% endif %}
+        </td>
+      </tr>
+    {% empty %}
+      <tr><td colspan="3" class="text-muted">No items yet.</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
 {% endblock %}

--- a/src/apps/ui/urls.py
+++ b/src/apps/ui/urls.py
@@ -100,6 +100,25 @@ urlpatterns = [
     path('funding-agreements/<int:pk>/edit/', views.crud_views.FundingAgreementUpdateView.as_view(), name='funding_agreement_edit'),
     path('funding-agreements/<int:pk>/delete/', views.crud_views.FundingAgreementDeleteView.as_view(), name='funding_agreement_delete'),
 
+    # StageReport lifecycle actions
+    path('projects/<int:project_pk>/stage-reports/<int:pk>/submit/', views.crud_views.StageReportSubmitView.as_view(), name='stage_report_submit'),
+    path('projects/<int:project_pk>/stage-reports/<int:pk>/endorse/', views.crud_views.StageReportEndorseView.as_view(), name='stage_report_endorse'),
+    path('projects/<int:project_pk>/stage-reports/<int:pk>/assess/', views.crud_views.StageReportAssessView.as_view(), name='stage_report_assess'),
+    path('projects/<int:project_pk>/stage-reports/<int:pk>/approve/', views.crud_views.StageReportApproveView.as_view(), name='stage_report_approve'),
+
+    # VariationItems (nested under Variation)
+    path('variations/<int:variation_pk>/items/create/', views.crud_views.VariationItemCreateView.as_view(), name='variation_item_create'),
+    path('variations/<int:variation_pk>/items/<int:pk>/edit/', views.crud_views.VariationItemUpdateView.as_view(), name='variation_item_edit'),
+    path('variations/<int:variation_pk>/items/<int:pk>/delete/', views.crud_views.VariationItemDeleteView.as_view(), name='variation_item_delete'),
+    path('variations/<int:pk>/execute/', views.crud_views.VariationExecuteView.as_view(), name='variation_execute'),
+
+    # Allocations (WorkFunding)
+    path('allocations/', views.crud_views.WorkFundingListView.as_view(), name='allocation_list'),
+    path('allocations/create/', views.crud_views.WorkFundingCreateView.as_view(), name='allocation_create'),
+    path('allocations/<int:pk>/', views.crud_views.WorkFundingDetailView.as_view(), name='allocation_detail'),
+    path('allocations/<int:pk>/edit/', views.crud_views.WorkFundingUpdateView.as_view(), name='allocation_edit'),
+    path('allocations/<int:pk>/delete/', views.crud_views.WorkFundingDeleteView.as_view(), name='allocation_delete'),
+
     # Brief Financial Approvals (nested under project)
     path('projects/<int:project_pk>/bfa/', views.crud_views.BriefFinancialApprovalListView.as_view(), name='bfa_list'),
     path('projects/<int:project_pk>/bfa/create/', views.crud_views.BriefFinancialApprovalCreateView.as_view(), name='bfa_create'),

--- a/src/apps/ui/views/crud_views.py
+++ b/src/apps/ui/views/crud_views.py
@@ -16,8 +16,8 @@ from django.utils import timezone
 from apps.core.models import (
     BriefFinancialApproval, Council, DevelopmentApplication, LandTenure,
     Program, Project, WorkType, FundingSchedule,
-    Variation, Payment, StageReport, QuarterlyReport,
-    FundingAgreement, FundingNotice, ExpenseClaim,
+    Variation, VariationItem, Payment, StageReport, QuarterlyReport,
+    FundingAgreement, FundingNotice, ExpenseClaim, WorkFunding,
 )
 
 
@@ -886,3 +886,185 @@ class BriefFinancialApprovalRejectView(LoginRequiredMixin, View):
         bfa.save()
         messages.success(request, 'Brief Financial Approval rejected.')
         return redirect('ui:bfa_detail', project_pk=project_pk, pk=pk)
+
+
+# ---------------------------------------------------------------------------
+# StageReport lifecycle actions (nested under project)
+# ---------------------------------------------------------------------------
+
+class StageReportSubmitView(LoginRequiredMixin, View):
+    def post(self, request, project_pk, pk):
+        report = get_object_or_404(StageReport, pk=pk, project_id=project_pk)
+        if report.status != StageReport.Status.DRAFT:
+            messages.error(request, 'Only draft reports can be submitted.')
+            return redirect('ui:stage_report_detail', project_pk=project_pk, pk=pk)
+        report.submit(request.user)
+        messages.success(request, 'Stage report submitted.')
+        return redirect('ui:stage_report_detail', project_pk=project_pk, pk=pk)
+
+
+class StageReportEndorseView(LoginRequiredMixin, View):
+    def post(self, request, project_pk, pk):
+        report = get_object_or_404(StageReport, pk=pk, project_id=project_pk)
+        if report.status != StageReport.Status.SUBMITTED:
+            messages.error(request, 'Only submitted reports can be endorsed.')
+            return redirect('ui:stage_report_detail', project_pk=project_pk, pk=pk)
+        report.endorse(request.user)
+        messages.success(request, 'Stage report endorsed.')
+        return redirect('ui:stage_report_detail', project_pk=project_pk, pk=pk)
+
+
+class StageReportAssessView(LoginRequiredMixin, View):
+    def post(self, request, project_pk, pk):
+        report = get_object_or_404(StageReport, pk=pk, project_id=project_pk)
+        if report.status != StageReport.Status.ENDORSED:
+            messages.error(request, 'Only endorsed reports can be assessed.')
+            return redirect('ui:stage_report_detail', project_pk=project_pk, pk=pk)
+        report.assess(request.user)
+        messages.success(request, 'Stage report assessed.')
+        return redirect('ui:stage_report_detail', project_pk=project_pk, pk=pk)
+
+
+class StageReportApproveView(LoginRequiredMixin, View):
+    def post(self, request, project_pk, pk):
+        report = get_object_or_404(StageReport, pk=pk, project_id=project_pk)
+        if report.status != StageReport.Status.ASSESSED:
+            messages.error(request, 'Only assessed reports can be approved.')
+            return redirect('ui:stage_report_detail', project_pk=project_pk, pk=pk)
+        report.approve(request.user)
+        messages.success(request, 'Stage report approved.')
+        return redirect('ui:stage_report_detail', project_pk=project_pk, pk=pk)
+
+
+# ---------------------------------------------------------------------------
+# VariationItem (nested under Variation)
+# ---------------------------------------------------------------------------
+
+class VariationItemCreateView(LoginRequiredMixin, CreateView):
+    model = VariationItem
+    template_name = 'crud/form.html'
+    fields = ['option', 'description', 'funding_schedule', 'council',
+              'stage1_target_date', 'stage2_target_date',
+              'original_scope', 'new_scope',
+              'original_amount', 'new_amount',
+              'monthly_required', 'quarterly_required', 'stage1_required', 'stage2_required']
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        if kwargs.get('instance') is None:
+            kwargs['instance'] = VariationItem(
+                variation_id=self.kwargs['variation_pk']
+            )
+        return kwargs
+
+    def get_success_url(self):
+        return reverse_lazy('ui:variation_detail', kwargs={'pk': self.kwargs['variation_pk']})
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['title'] = 'Add Variation Item'
+        ctx['back_url'] = reverse_lazy('ui:variation_detail', kwargs={'pk': self.kwargs['variation_pk']})
+        return ctx
+
+
+class VariationItemUpdateView(LoginRequiredMixin, UpdateView):
+    model = VariationItem
+    template_name = 'crud/form.html'
+    fields = ['option', 'description', 'funding_schedule', 'council',
+              'stage1_target_date', 'stage2_target_date',
+              'original_scope', 'new_scope',
+              'original_amount', 'new_amount',
+              'monthly_required', 'quarterly_required', 'stage1_required', 'stage2_required']
+
+    def get_success_url(self):
+        return reverse_lazy('ui:variation_detail', kwargs={'pk': self.kwargs['variation_pk']})
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['title'] = f'Edit Variation Item #{self.object.pk}'
+        ctx['back_url'] = reverse_lazy('ui:variation_detail', kwargs={'pk': self.kwargs['variation_pk']})
+        return ctx
+
+
+class VariationItemDeleteView(LoginRequiredMixin, DeleteView):
+    model = VariationItem
+    template_name = 'crud/confirm_delete.html'
+
+    def get_success_url(self):
+        return reverse_lazy('ui:variation_detail', kwargs={'pk': self.kwargs['variation_pk']})
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['back_url'] = reverse_lazy('ui:variation_detail', kwargs={'pk': self.kwargs['variation_pk']})
+        return ctx
+
+
+class VariationExecuteView(LoginRequiredMixin, View):
+    def post(self, request, pk):
+        variation = get_object_or_404(Variation, pk=pk)
+        if variation.status not in (Variation.Status.DRAFT, Variation.Status.COUNCIL_SIGNED):
+            messages.error(request, 'Only draft or council-signed variations can be executed.')
+            return redirect('ui:variation_detail', pk=pk)
+        variation.status = Variation.Status.EXECUTED
+        variation.save()
+        messages.success(request, 'Variation executed.')
+        return redirect('ui:variation_detail', pk=pk)
+
+
+# ---------------------------------------------------------------------------
+# WorkFunding / Allocation
+# ---------------------------------------------------------------------------
+
+class WorkFundingListView(LoginRequiredMixin, ListView):
+    model = WorkFunding
+    template_name = 'allocations/list.html'
+    context_object_name = 'allocations'
+    paginate_by = 50
+
+    def get_queryset(self):
+        return WorkFunding.objects.select_related(
+            'funding_schedule', 'project', 'work'
+        ).order_by('funding_schedule', 'id')
+
+
+class WorkFundingCreateView(LoginRequiredMixin, CreateView):
+    model = WorkFunding
+    template_name = 'crud/form.html'
+    fields = ['funding_schedule', 'project', 'work', 'cost_centre', 'gl_code', 'tax_code', 'amount', 'notes']
+    success_url = reverse_lazy('ui:allocation_list')
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['title'] = 'Create Allocation'
+        ctx['back_url'] = reverse_lazy('ui:allocation_list')
+        return ctx
+
+
+class WorkFundingDetailView(LoginRequiredMixin, DetailView):
+    model = WorkFunding
+    template_name = 'allocations/detail.html'
+    context_object_name = 'allocation'
+
+
+class WorkFundingUpdateView(LoginRequiredMixin, UpdateView):
+    model = WorkFunding
+    template_name = 'crud/form.html'
+    fields = ['funding_schedule', 'project', 'work', 'cost_centre', 'gl_code', 'tax_code', 'amount', 'notes']
+    success_url = reverse_lazy('ui:allocation_list')
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['title'] = f'Edit Allocation #{self.object.pk}'
+        ctx['back_url'] = reverse_lazy('ui:allocation_list')
+        return ctx
+
+
+class WorkFundingDeleteView(LoginRequiredMixin, DeleteView):
+    model = WorkFunding
+    template_name = 'crud/confirm_delete.html'
+    success_url = reverse_lazy('ui:allocation_list')
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['back_url'] = reverse_lazy('ui:allocation_list')
+        return ctx

--- a/tests/test_issue_16_17_20.py
+++ b/tests/test_issue_16_17_20.py
@@ -1,0 +1,383 @@
+"""
+Tests for issues #16 (VariationItem CRUD + execute), #17 (WorkFunding/Allocation CRUD),
+#20 (StageReport lifecycle actions: submit/endorse/assess/approve).
+"""
+import pytest
+from decimal import Decimal
+from datetime import date
+from django.test import Client
+from django.contrib.auth.models import User
+
+from apps.core.models import (
+    Council, Program, Project, FundingSchedule,
+    Variation, VariationItem, StageReport, WorkFunding, Profile,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def council():
+    return Council.objects.create(name='Test Council', region='QLD')
+
+
+@pytest.fixture
+def program(council):
+    return Program.objects.create(
+        name='Test Program',
+        funding_source=Program.FundingSource.STATE,
+        budget=Decimal('1000000'),
+    )
+
+
+@pytest.fixture
+def project(council, program):
+    return Project.objects.create(
+        name='Test Project', council=council, program=program,
+        state=Project.State.PROSPECTIVE, financial_year='2025-2026',
+    )
+
+
+@pytest.fixture
+def funding_schedule(project):
+    return FundingSchedule.objects.create(
+        project=project,
+        amount=Decimal('500000'),
+        contingency=Decimal('50000'),
+        payment_split=FundingSchedule.PaymentSplit.STANDARD,
+    )
+
+
+@pytest.fixture
+def variation(funding_schedule):
+    return Variation.objects.create(
+        funding_schedule=funding_schedule,
+        variation_option=Variation.VariationOption.OPTION_1_ADD_FS,
+        status=Variation.Status.DRAFT,
+        description='Test variation',
+    )
+
+
+@pytest.fixture
+def variation_item(variation):
+    return VariationItem.objects.create(
+        variation=variation,
+        option=VariationItem.OptionType.OPTION_1,
+        description='Add a new funding schedule',
+    )
+
+
+@pytest.fixture
+def stage_report(project, funding_schedule):
+    return StageReport.objects.create(
+        project=project,
+        funding_schedule=funding_schedule,
+        stage_type=StageReport.StageType.STAGE1,
+        status=StageReport.Status.DRAFT,
+    )
+
+
+@pytest.fixture
+def auth_client(council):
+    client = Client()
+    user = User.objects.create_user(username='test_user_16_17_20', password='pass')
+    Profile.objects.create(user=user, council=council, officer_role=Profile.OfficerRole.SENIOR_OFFICER)
+    client.force_login(user)
+    return client, user
+
+
+# ===========================================================================
+# Issue #20 — StageReport lifecycle
+# ===========================================================================
+
+@pytest.mark.django_db
+class TestStageReportSubmit:
+    def test_submit_draft_report(self, auth_client, stage_report):
+        client, _ = auth_client
+        response = client.post(
+            f'/projects/{stage_report.project_id}/stage-reports/{stage_report.pk}/submit/'
+        )
+        assert response.status_code == 302
+        stage_report.refresh_from_db()
+        assert stage_report.status == StageReport.Status.SUBMITTED
+
+    def test_submit_non_draft_fails(self, auth_client, stage_report):
+        client, _ = auth_client
+        stage_report.status = StageReport.Status.SUBMITTED
+        stage_report.save()
+        client.post(f'/projects/{stage_report.project_id}/stage-reports/{stage_report.pk}/submit/')
+        stage_report.refresh_from_db()
+        assert stage_report.status == StageReport.Status.SUBMITTED  # unchanged
+
+    def test_submit_requires_login(self, stage_report):
+        response = Client().post(
+            f'/projects/{stage_report.project_id}/stage-reports/{stage_report.pk}/submit/'
+        )
+        assert response.status_code == 302
+        assert '/accounts/login/' in response['Location']
+
+
+@pytest.mark.django_db
+class TestStageReportEndorse:
+    def test_endorse_submitted_report(self, auth_client, stage_report):
+        client, user = auth_client
+        stage_report.status = StageReport.Status.SUBMITTED
+        stage_report.save()
+        client.post(f'/projects/{stage_report.project_id}/stage-reports/{stage_report.pk}/endorse/')
+        stage_report.refresh_from_db()
+        assert stage_report.status == StageReport.Status.ENDORSED
+        assert stage_report.endorsed_by == user
+
+    def test_endorse_draft_fails(self, auth_client, stage_report):
+        client, _ = auth_client
+        client.post(f'/projects/{stage_report.project_id}/stage-reports/{stage_report.pk}/endorse/')
+        stage_report.refresh_from_db()
+        assert stage_report.status == StageReport.Status.DRAFT
+
+
+@pytest.mark.django_db
+class TestStageReportAssess:
+    def test_assess_endorsed_report(self, auth_client, stage_report):
+        client, user = auth_client
+        stage_report.status = StageReport.Status.ENDORSED
+        stage_report.save()
+        client.post(f'/projects/{stage_report.project_id}/stage-reports/{stage_report.pk}/assess/')
+        stage_report.refresh_from_db()
+        assert stage_report.status == StageReport.Status.ASSESSED
+        assert stage_report.assessed_by == user
+
+    def test_assess_submitted_fails(self, auth_client, stage_report):
+        client, _ = auth_client
+        stage_report.status = StageReport.Status.SUBMITTED
+        stage_report.save()
+        client.post(f'/projects/{stage_report.project_id}/stage-reports/{stage_report.pk}/assess/')
+        stage_report.refresh_from_db()
+        assert stage_report.status == StageReport.Status.SUBMITTED
+
+
+@pytest.mark.django_db
+class TestStageReportApprove:
+    def test_approve_assessed_report(self, auth_client, stage_report):
+        client, user = auth_client
+        stage_report.status = StageReport.Status.ASSESSED
+        stage_report.save()
+        client.post(f'/projects/{stage_report.project_id}/stage-reports/{stage_report.pk}/approve/')
+        stage_report.refresh_from_db()
+        assert stage_report.status == StageReport.Status.APPROVED
+        assert stage_report.approved_by == user
+
+    def test_approve_endorsed_fails(self, auth_client, stage_report):
+        client, _ = auth_client
+        stage_report.status = StageReport.Status.ENDORSED
+        stage_report.save()
+        client.post(f'/projects/{stage_report.project_id}/stage-reports/{stage_report.pk}/approve/')
+        stage_report.refresh_from_db()
+        assert stage_report.status == StageReport.Status.ENDORSED
+
+
+# ===========================================================================
+# Issue #16 — VariationItem CRUD + execute
+# ===========================================================================
+
+@pytest.mark.django_db
+class TestVariationItemCreate:
+    def test_create_get(self, auth_client, variation):
+        client, _ = auth_client
+        response = client.get(f'/variations/{variation.pk}/items/create/')
+        assert response.status_code == 200
+
+    def test_create_post_creates_item(self, auth_client, variation):
+        client, _ = auth_client
+        response = client.post(f'/variations/{variation.pk}/items/create/', {
+            'option': 'OPTION_1',
+            'description': 'Add new FS for project',
+        }, follow=True)
+        assert response.status_code == 200
+        assert VariationItem.objects.filter(variation=variation, option='OPTION_1').exists()
+
+    def test_create_requires_login(self, variation):
+        response = Client().get(f'/variations/{variation.pk}/items/create/')
+        assert response.status_code == 302
+
+
+@pytest.mark.django_db
+class TestVariationItemEdit:
+    def test_edit_get(self, auth_client, variation_item, variation):
+        client, _ = auth_client
+        response = client.get(f'/variations/{variation.pk}/items/{variation_item.pk}/edit/')
+        assert response.status_code == 200
+
+    def test_edit_post_updates_item(self, auth_client, variation_item, variation):
+        client, _ = auth_client
+        client.post(f'/variations/{variation.pk}/items/{variation_item.pk}/edit/', {
+            'option': 'OPTION_2',
+            'description': 'Remove old FS',
+        })
+        variation_item.refresh_from_db()
+        assert variation_item.option == 'OPTION_2'
+        assert variation_item.description == 'Remove old FS'
+
+
+@pytest.mark.django_db
+class TestVariationItemDelete:
+    def test_delete_get(self, auth_client, variation_item, variation):
+        client, _ = auth_client
+        response = client.get(f'/variations/{variation.pk}/items/{variation_item.pk}/delete/')
+        assert response.status_code == 200
+
+    def test_delete_post_removes_item(self, auth_client, variation_item, variation):
+        client, _ = auth_client
+        item_id = variation_item.pk
+        client.post(f'/variations/{variation.pk}/items/{item_id}/delete/')
+        assert not VariationItem.objects.filter(pk=item_id).exists()
+
+
+@pytest.mark.django_db
+class TestVariationExecute:
+    def test_execute_draft_variation(self, auth_client, variation):
+        client, _ = auth_client
+        client.post(f'/variations/{variation.pk}/execute/')
+        variation.refresh_from_db()
+        assert variation.status == Variation.Status.EXECUTED
+
+    def test_execute_council_signed_variation(self, auth_client, variation):
+        client, _ = auth_client
+        variation.status = Variation.Status.COUNCIL_SIGNED
+        variation.save()
+        client.post(f'/variations/{variation.pk}/execute/')
+        variation.refresh_from_db()
+        assert variation.status == Variation.Status.EXECUTED
+
+    def test_execute_already_executed_is_noop(self, auth_client, variation):
+        client, _ = auth_client
+        variation.status = Variation.Status.EXECUTED
+        variation.save()
+        client.post(f'/variations/{variation.pk}/execute/')
+        variation.refresh_from_db()
+        assert variation.status == Variation.Status.EXECUTED  # unchanged, error redirected
+
+    def test_execute_requires_login(self, variation):
+        response = Client().post(f'/variations/{variation.pk}/execute/')
+        assert response.status_code == 302
+        assert '/accounts/login/' in response['Location']
+
+
+# ===========================================================================
+# Issue #17 — WorkFunding / Allocation CRUD
+# ===========================================================================
+
+@pytest.mark.django_db
+class TestAllocationList:
+    def test_list_get(self, auth_client):
+        client, _ = auth_client
+        response = client.get('/allocations/')
+        assert response.status_code == 200
+
+    def test_list_requires_login(self):
+        response = Client().get('/allocations/')
+        assert response.status_code == 302
+        assert '/accounts/login/' in response['Location']
+
+    def test_list_shows_allocation(self, auth_client, funding_schedule, project):
+        client, _ = auth_client
+        WorkFunding.objects.create(
+            funding_schedule=funding_schedule, project=project,
+            cost_centre='316333', amount=Decimal('100000'),
+        )
+        response = client.get('/allocations/')
+        assert response.status_code == 200
+        assert b'316333' in response.content
+
+
+@pytest.mark.django_db
+class TestAllocationCreate:
+    def test_create_get(self, auth_client):
+        client, _ = auth_client
+        response = client.get('/allocations/create/')
+        assert response.status_code == 200
+
+    def test_create_post_project_allocation(self, auth_client, funding_schedule, project):
+        client, _ = auth_client
+        response = client.post('/allocations/create/', {
+            'funding_schedule': funding_schedule.pk,
+            'project': project.pk,
+            'cost_centre': '999001',
+            'gl_code': 'GL001',
+            'tax_code': 'GST',
+            'amount': '200000.00',
+        }, follow=True)
+        assert response.status_code == 200
+        assert WorkFunding.objects.filter(cost_centre='999001', project=project).exists()
+
+    def test_create_requires_login(self):
+        response = Client().get('/allocations/create/')
+        assert response.status_code == 302
+
+
+@pytest.mark.django_db
+class TestAllocationDetail:
+    def test_detail_get(self, auth_client, funding_schedule, project):
+        client, _ = auth_client
+        allocation = WorkFunding.objects.create(
+            funding_schedule=funding_schedule, project=project,
+            cost_centre='316001', amount=Decimal('50000'),
+        )
+        response = client.get(f'/allocations/{allocation.pk}/')
+        assert response.status_code == 200
+        assert b'316001' in response.content
+
+    def test_detail_404_on_missing(self, auth_client):
+        client, _ = auth_client
+        response = client.get('/allocations/99999/')
+        assert response.status_code == 404
+
+
+@pytest.mark.django_db
+class TestAllocationEdit:
+    def test_edit_get(self, auth_client, funding_schedule, project):
+        client, _ = auth_client
+        allocation = WorkFunding.objects.create(
+            funding_schedule=funding_schedule, project=project,
+            cost_centre='316001',
+        )
+        response = client.get(f'/allocations/{allocation.pk}/edit/')
+        assert response.status_code == 200
+
+    def test_edit_post_updates_allocation(self, auth_client, funding_schedule, project):
+        client, _ = auth_client
+        allocation = WorkFunding.objects.create(
+            funding_schedule=funding_schedule, project=project,
+            cost_centre='316001',
+        )
+        client.post(f'/allocations/{allocation.pk}/edit/', {
+            'funding_schedule': funding_schedule.pk,
+            'project': project.pk,
+            'cost_centre': '999999',
+            'amount': '300000.00',
+        })
+        allocation.refresh_from_db()
+        assert allocation.cost_centre == '999999'
+
+
+@pytest.mark.django_db
+class TestAllocationDelete:
+    def test_delete_get(self, auth_client, funding_schedule, project):
+        client, _ = auth_client
+        allocation = WorkFunding.objects.create(
+            funding_schedule=funding_schedule, project=project,
+            cost_centre='316001',
+        )
+        response = client.get(f'/allocations/{allocation.pk}/delete/')
+        assert response.status_code == 200
+
+    def test_delete_post_removes_allocation(self, auth_client, funding_schedule, project):
+        client, _ = auth_client
+        allocation = WorkFunding.objects.create(
+            funding_schedule=funding_schedule, project=project,
+            cost_centre='316001',
+        )
+        pk = allocation.pk
+        client.post(f'/allocations/{pk}/delete/')
+        assert not WorkFunding.objects.filter(pk=pk).exists()


### PR DESCRIPTION
…fecycle (closes #16, #17, #20)

- StageReport: POST-only submit/endorse/assess/approve action views with guard checks; updated detail template with contextual action buttons
- VariationItem: create/edit/delete views nested under Variation (variation_pk); VariationExecuteView sets status=EXECUTED with guard for draft/council-signed only
- WorkFunding (Allocation): full CRUD at /allocations/ with XOR project/work enforced at DB level; list/detail templates
- Export VariationItem from core models __init__
- 32 new tests, all passing (336 total)

## Summary
Explain what this PR does and why.

Fixes #<issue_number>  <!-- Link the issue this PR resolves -->

## Changes
- [x] Describe key changes (models, views, forms, etc.)
- [x] Add migrations if applicable
- [x] Update tests / add new ones

## Testing
Describe how you tested the changes:
- [ ] Ran `python manage.py check`
- [ ] Verified `runserver` starts successfully
- [ ] Manual browser test on affected routes
- [ ] Unit tests pass (`pytest` or Django test suite)

## Notes
Anything reviewers or Roo Code should be aware of (e.g. partial fixes, TODOs, dependencies).