### PR TITLE
feat(#34): wire AuditLog signals with CurrentUserMiddleware

### DIFF
--- a/src/apps/core/admin.py
+++ b/src/apps/core/admin.py
@@ -1,0 +1,20 @@
+from django.contrib import admin
+from apps.core.models import AuditLog
+
+
+@admin.register(AuditLog)
+class AuditLogAdmin(admin.ModelAdmin):
+    list_display = ('timestamp', 'entity_type', 'entity_id', 'action', 'user')
+    list_filter = ('action', 'entity_type')
+    search_fields = ('entity_type', 'entity_id', 'user__username')
+    readonly_fields = ('user', 'timestamp', 'entity_type', 'entity_id', 'action', 'before_json', 'after_json')
+    ordering = ('-timestamp',)
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False

--- a/src/apps/core/business_rules.py
+++ b/src/apps/core/business_rules.py
@@ -19,10 +19,13 @@ from decimal import Decimal
 
 def _json_safe(val):
     """Convert a value to be JSON-serializable."""
+    import datetime as _dt
     if hasattr(val, 'pk'):
         return val.pk
     if isinstance(val, Decimal):
         return str(val)
+    if isinstance(val, (_dt.datetime, _dt.date, _dt.time)):
+        return val.isoformat()
     if isinstance(val, (set, frozenset)):
         return list(val)
     if hasattr(val, '__iter__') and not isinstance(val, str):
@@ -36,9 +39,6 @@ def _json_safe(val):
 def log_workflow_action(entity_type, entity_id, action_type, user=None, metadata=None):
     """Create a WorkflowAction record. Silently no-ops if table not ready."""
     try:
-        import sys
-        if 'pytest' in sys.modules:
-            return
         from apps.core.models import WorkflowAction
         WorkflowAction.objects.create(
             entity_type=entity_type,
@@ -54,9 +54,6 @@ def log_workflow_action(entity_type, entity_id, action_type, user=None, metadata
 def log_audit(user, action, instance, old_values=None):
     """Create an AuditLog record for data-level changes. Silently no-ops if table not ready."""
     try:
-        import sys
-        if 'pytest' in sys.modules:
-            return
         from apps.core.models import AuditLog
         before = {}
         after = {}

--- a/src/apps/core/middleware.py
+++ b/src/apps/core/middleware.py
@@ -1,0 +1,22 @@
+"""Thread-local middleware to capture the current request user for signal handlers."""
+import threading
+
+_thread_locals = threading.local()
+
+
+def get_current_user():
+    return getattr(_thread_locals, 'user', None)
+
+
+class CurrentUserMiddleware:
+    """Store request.user in thread-local so signals can access it without being passed explicitly."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        _thread_locals.user = getattr(request, 'user', None)
+        try:
+            return self.get_response(request)
+        finally:
+            _thread_locals.user = None

--- a/src/apps/core/signals.py
+++ b/src/apps/core/signals.py
@@ -10,6 +10,7 @@ Handles:
 from django.db.models.signals import post_save, pre_save, pre_delete
 from django.dispatch import receiver
 from django.utils import timezone
+from apps.core.middleware import get_current_user
 
 
 FINANCIAL_MODELS = {
@@ -54,11 +55,12 @@ def audit_log_post_save(sender, instance, created, **kwargs):
     
     action = 'CREATE' if created else 'UPDATE'
     old_values = getattr(instance, '_pre_save_state', {})
-    
+    user = getattr(instance, '_current_user', None) or get_current_user()
+
     try:
         from apps.core.business_rules import log_audit
         log_audit(
-            user=getattr(instance, '_current_user', None),
+            user=user,
             action=action,
             instance=instance,
             old_values=old_values if not created else {}
@@ -85,10 +87,11 @@ def audit_log_pre_delete(sender, instance, **kwargs):
             val = list(val)
         old_values[f.name] = val
     
+    user = getattr(instance, '_current_user', None) or get_current_user()
     try:
         from apps.core.business_rules import log_audit
         log_audit(
-            user=getattr(instance, '_current_user', None),
+            user=user,
             action='DELETE',
             instance=instance,
             old_values=old_values
@@ -187,8 +190,8 @@ def emit_workflow_action(sender, instance, created, **kwargs):
         from apps.core.business_rules import log_workflow_action
         from apps.core.models import WorkflowAction
         
-        user = getattr(instance, '_current_user', None)
-        
+        user = getattr(instance, '_current_user', None) or get_current_user()
+
         if created:
             action_type = 'CREATE'
         elif hasattr(instance, '_state_action_type') and instance._state_action_type:

--- a/src/apps/ui/templates/funding_schedules/detail.html
+++ b/src/apps/ui/templates/funding_schedules/detail.html
@@ -43,4 +43,28 @@
     <dt class="col-sm-3">Payment Rule</dt><dd class="col-sm-9">{{ funding_schedule.payment_rule|default:"-" }}</dd>
   </dl>
 </div></div>
+
+{% if audit_logs %}
+<div class="mt-4">
+  <h6 class="text-muted">Audit History (last {{ audit_logs|length }})</h6>
+  <div class="card">
+    <div class="table-responsive">
+      <table class="table table-sm mb-0">
+        <thead class="table-light">
+          <tr><th>Time</th><th>Action</th><th>User</th></tr>
+        </thead>
+        <tbody>
+          {% for log in audit_logs %}
+          <tr>
+            <td>{{ log.timestamp|date:"Y-m-d H:i" }}</td>
+            <td><span class="badge {% if log.action == 'CREATE' %}bg-success{% elif log.action == 'DELETE' %}bg-danger{% else %}bg-secondary{% endif %}">{{ log.action }}</span></td>
+            <td>{{ log.user|default:"—" }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+{% endif %}
 {% endblock %}

--- a/src/apps/ui/templates/payments/detail.html
+++ b/src/apps/ui/templates/payments/detail.html
@@ -42,4 +42,28 @@
     <dt class="col-sm-3">Reference</dt><dd class="col-sm-9">{{ payment.reference|default:"-" }}</dd>
   </dl>
 </div></div>
+
+{% if audit_logs %}
+<div class="mt-4">
+  <h6 class="text-muted">Audit History (last {{ audit_logs|length }})</h6>
+  <div class="card">
+    <div class="table-responsive">
+      <table class="table table-sm mb-0">
+        <thead class="table-light">
+          <tr><th>Time</th><th>Action</th><th>User</th></tr>
+        </thead>
+        <tbody>
+          {% for log in audit_logs %}
+          <tr>
+            <td>{{ log.timestamp|date:"Y-m-d H:i" }}</td>
+            <td><span class="badge {% if log.action == 'CREATE' %}bg-success{% elif log.action == 'DELETE' %}bg-danger{% else %}bg-secondary{% endif %}">{{ log.action }}</span></td>
+            <td>{{ log.user|default:"—" }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+{% endif %}
 {% endblock %}

--- a/src/apps/ui/views/crud_views.py
+++ b/src/apps/ui/views/crud_views.py
@@ -267,6 +267,14 @@ class FundingScheduleDetailView(LoginRequiredMixin, DetailView):
     template_name = 'funding_schedules/detail.html'
     context_object_name = 'funding_schedule'
 
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        from apps.core.models import AuditLog
+        ctx['audit_logs'] = AuditLog.objects.filter(
+            entity_type='fundingschedule', entity_id=self.object.pk
+        ).order_by('-timestamp')[:10]
+        return ctx
+
 
 class FundingScheduleUpdateView(LoginRequiredMixin, UpdateView):
     model = FundingSchedule
@@ -382,6 +390,14 @@ class PaymentDetailView(LoginRequiredMixin, DetailView):
     model = Payment
     template_name = 'payments/detail.html'
     context_object_name = 'payment'
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        from apps.core.models import AuditLog
+        ctx['audit_logs'] = AuditLog.objects.filter(
+            entity_type='payment', entity_id=self.object.pk
+        ).order_by('-timestamp')[:10]
+        return ctx
 
 
 class PaymentUpdateView(LoginRequiredMixin, UpdateView):

--- a/src/ricdapp/settings.py
+++ b/src/ricdapp/settings.py
@@ -36,6 +36,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'apps.core.middleware.CurrentUserMiddleware',
 ]
 
 ROOT_URLCONF = 'ricdapp.urls'

--- a/tests/test_issue_34_audit_log.py
+++ b/tests/test_issue_34_audit_log.py
@@ -1,0 +1,312 @@
+"""
+Tests for issue #34 — AuditLog signal wiring.
+
+Covers:
+- AuditLog created on CREATE of financial models
+- AuditLog created on UPDATE (with before/after JSON)
+- AuditLog created on DELETE
+- user is captured from thread-local (CurrentUserMiddleware)
+- AuditLog is immutable (no update/delete in admin)
+- Detail views expose audit_logs context
+"""
+import pytest
+from decimal import Decimal
+from unittest.mock import patch
+from django.test import RequestFactory, Client
+from django.contrib.auth.models import User
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username='auditor', password='pass')
+
+
+@pytest.fixture
+def council(db):
+    from apps.core.models import Council
+    return Council.objects.create(
+        name='Test Council',
+        region='Region',
+        state_electorate='SE',
+        federal_electorate='FE',
+    )
+
+
+@pytest.fixture
+def program(db):
+    from apps.core.models import Program
+    return Program.objects.create(
+        name='Test Program',
+        funding_source='STATE',
+        budget=Decimal('5000000'),
+        gl_code='GL001',
+        business_case_reference='BC-001',
+    )
+
+
+@pytest.fixture
+def project(db, council, program):
+    from apps.core.models import Project
+    return Project.objects.create(
+        name='Audit Test Project',
+        council=council,
+        program=program,
+        state='PROSPECTIVE',
+        dwelling_status='PROSPECTIVE',
+        financial_year='2025-2026',
+    )
+
+
+@pytest.fixture
+def funding_schedule(db, project):
+    from apps.core.models import FundingSchedule
+    return FundingSchedule.objects.create(
+        project=project,
+        amount=Decimal('200000'),
+        contingency=Decimal('20000'),
+        payment_split='STANDARD',
+    )
+
+
+# ===========================================================================
+# AuditLog creation via signals
+# ===========================================================================
+
+@pytest.mark.django_db
+class TestAuditLogCreate:
+    def test_create_financial_model_emits_audit_log(self, project):
+        from apps.core.models import FundingSchedule, AuditLog
+        before_count = AuditLog.objects.count()
+        FundingSchedule.objects.create(
+            project=project,
+            amount=Decimal('100000'),
+            contingency=Decimal('10000'),
+            payment_split='STANDARD',
+        )
+        assert AuditLog.objects.count() == before_count + 1
+        log = AuditLog.objects.filter(entity_type='fundingschedule').latest('timestamp')
+        assert log.action == 'CREATE'
+        assert log.before_json == {}
+
+    def test_create_log_captures_after_values(self, project):
+        from apps.core.models import FundingSchedule, AuditLog
+        fs = FundingSchedule.objects.create(
+            project=project,
+            amount=Decimal('150000'),
+            contingency=Decimal('15000'),
+            payment_split='STANDARD',
+        )
+        log = AuditLog.objects.filter(entity_type='fundingschedule', entity_id=fs.pk).latest('timestamp')
+        assert 'amount' in log.after_json
+        assert log.action == 'CREATE'
+
+    def test_non_financial_model_does_not_emit_audit_log(self, council):
+        from apps.core.models import AuditLog
+        # Council is not in FINANCIAL_MODELS — no audit log expected
+        before_count = AuditLog.objects.filter(entity_type='council').count()
+        council.name = 'Updated Council Name'
+        council.save()
+        assert AuditLog.objects.filter(entity_type='council').count() == before_count
+
+
+@pytest.mark.django_db
+class TestAuditLogUpdate:
+    def test_update_emits_audit_log_with_before_after(self, funding_schedule):
+        from apps.core.models import FundingSchedule, AuditLog
+        old_amount = funding_schedule.amount
+        funding_schedule.amount = Decimal('300000')
+        funding_schedule.save()
+
+        log = AuditLog.objects.filter(
+            entity_type='fundingschedule',
+            entity_id=funding_schedule.pk,
+            action='UPDATE',
+        ).latest('timestamp')
+        # DecimalField stores with full precision (e.g. '200000.00'), compare as Decimal
+        assert Decimal(log.before_json.get('amount')) == old_amount
+        assert Decimal(log.after_json.get('amount')) == Decimal('300000')
+
+    def test_update_log_action_is_update(self, funding_schedule):
+        from apps.core.models import AuditLog
+        funding_schedule.status = 'READY'
+        funding_schedule.save()
+        log = AuditLog.objects.filter(
+            entity_type='fundingschedule',
+            entity_id=funding_schedule.pk,
+            action='UPDATE',
+        ).latest('timestamp')
+        assert log.action == 'UPDATE'
+
+
+@pytest.mark.django_db
+class TestAuditLogDelete:
+    def test_delete_emits_audit_log(self, funding_schedule):
+        from apps.core.models import AuditLog
+        pk = funding_schedule.pk
+        funding_schedule.delete()
+        log = AuditLog.objects.filter(
+            entity_type='fundingschedule',
+            entity_id=pk,
+            action='DELETE',
+        ).first()
+        assert log is not None
+        assert log.action == 'DELETE'
+        assert 'amount' in log.before_json
+
+    def test_delete_log_has_before_state(self, funding_schedule):
+        from apps.core.models import AuditLog
+        pk = funding_schedule.pk
+        expected_amount = str(funding_schedule.amount)
+        funding_schedule.delete()
+        log = AuditLog.objects.filter(entity_type='fundingschedule', entity_id=pk).first()
+        assert log.before_json.get('amount') == expected_amount
+
+
+# ===========================================================================
+# Thread-local user capture via CurrentUserMiddleware
+# ===========================================================================
+
+@pytest.mark.django_db
+class TestCurrentUserMiddleware:
+    def test_middleware_sets_thread_local_user(self):
+        from apps.core.middleware import CurrentUserMiddleware, get_current_user
+
+        captured = []
+
+        def get_response(request):
+            captured.append(get_current_user())
+            from django.http import HttpResponse
+            return HttpResponse()
+
+        middleware = CurrentUserMiddleware(get_response)
+        request = RequestFactory().get('/')
+        request.user = User.objects.create_user(username='mw_user', password='x')
+        middleware(request)
+        assert captured[0] == request.user
+
+    def test_middleware_clears_user_after_response(self):
+        from apps.core.middleware import CurrentUserMiddleware, get_current_user
+
+        def get_response(request):
+            from django.http import HttpResponse
+            return HttpResponse()
+
+        middleware = CurrentUserMiddleware(get_response)
+        request = RequestFactory().get('/')
+        request.user = User.objects.create_user(username='mw_user2', password='x')
+        middleware(request)
+        assert get_current_user() is None
+
+    def test_audit_log_captures_user_from_thread_local(self, project):
+        from apps.core.models import FundingSchedule, AuditLog
+        from apps.core.middleware import _thread_locals
+
+        actor = User.objects.create_user(username='fs_actor', password='x')
+        _thread_locals.user = actor
+        try:
+            fs = FundingSchedule.objects.create(
+                project=project,
+                amount=Decimal('50000'),
+                contingency=Decimal('5000'),
+                payment_split='STANDARD',
+            )
+        finally:
+            _thread_locals.user = None
+
+        log = AuditLog.objects.filter(entity_type='fundingschedule', entity_id=fs.pk).latest('timestamp')
+        assert log.user == actor
+
+    def test_audit_log_user_is_none_without_middleware(self, project):
+        from apps.core.models import FundingSchedule, AuditLog
+        fs = FundingSchedule.objects.create(
+            project=project,
+            amount=Decimal('75000'),
+            contingency=Decimal('7500'),
+            payment_split='STANDARD',
+        )
+        log = AuditLog.objects.filter(entity_type='fundingschedule', entity_id=fs.pk).latest('timestamp')
+        assert log.user is None
+
+
+# ===========================================================================
+# AuditLog immutability
+# ===========================================================================
+
+@pytest.mark.django_db
+class TestAuditLogImmutability:
+    def test_audit_log_has_no_update_method(self, funding_schedule):
+        from apps.core.models import AuditLog
+        log = AuditLog.objects.filter(entity_type='fundingschedule').first()
+        # AuditLog model should not define a custom save that allows re-save
+        # The admin disallows change/delete — here we verify admin permission helpers
+        from apps.core.admin import AuditLogAdmin
+        from django.contrib.admin.sites import AdminSite
+        admin = AuditLogAdmin(AuditLog, AdminSite())
+        assert not admin.has_add_permission(None)
+        assert not admin.has_change_permission(None)
+        assert not admin.has_delete_permission(None)
+
+    def test_audit_log_is_created_on_funding_schedule_save(self, funding_schedule):
+        from apps.core.models import AuditLog
+        count = AuditLog.objects.filter(
+            entity_type='fundingschedule', entity_id=funding_schedule.pk
+        ).count()
+        assert count >= 1
+
+
+# ===========================================================================
+# Detail view exposes audit_logs context
+# ===========================================================================
+
+@pytest.mark.django_db
+class TestDetailViewAuditLogContext:
+    def test_funding_schedule_detail_includes_audit_logs(self, funding_schedule):
+        from apps.core.models import AuditLog
+        from apps.ui.views.crud_views import FundingScheduleDetailView
+        from django.test import RequestFactory
+
+        request = RequestFactory().get('/')
+        request.user = User.objects.create_user(username='viewer', password='x')
+
+        view = FundingScheduleDetailView()
+        view.request = request
+        view.kwargs = {'pk': funding_schedule.pk}
+        view.object = funding_schedule
+
+        ctx = view.get_context_data()
+        assert 'audit_logs' in ctx
+        # All returned entries should belong to this entity
+        for log in ctx['audit_logs']:
+            assert log.entity_type == 'fundingschedule'
+            assert log.entity_id == funding_schedule.pk
+
+    def test_audit_logs_capped_at_10(self, project):
+        from apps.core.models import FundingSchedule, AuditLog
+        from apps.ui.views.crud_views import FundingScheduleDetailView
+        from django.test import RequestFactory
+
+        fs = FundingSchedule.objects.create(
+            project=project,
+            amount=Decimal('100000'),
+            contingency=Decimal('10000'),
+            payment_split='STANDARD',
+        )
+        # Create 15 extra audit entries
+        for _ in range(15):
+            AuditLog.objects.create(
+                entity_type='fundingschedule',
+                entity_id=fs.pk,
+                action='UPDATE',
+                before_json={},
+                after_json={},
+            )
+
+        request = RequestFactory().get('/')
+        request.user = User.objects.create_user(username='viewer2', password='x')
+        view = FundingScheduleDetailView()
+        view.request = request
+        view.kwargs = {'pk': fs.pk}
+        view.object = fs
+
+        ctx = view.get_context_data()
+        assert len(ctx['audit_logs']) <= 10

--- a/tests/test_workflow_action_audit.py
+++ b/tests/test_workflow_action_audit.py
@@ -279,6 +279,8 @@ class TestAuditTrailSequence:
 
     def test_workflow_action_history(self, funding_schedule, actor_user):
         """Test WorkflowAction history can be queried"""
+        # Clear any signal-emitted entries from fixture setup before asserting exact count
+        WorkflowAction.objects.filter(entity_type="FundingSchedule", entity_id=funding_schedule.id).delete()
         WorkflowAction.objects.create(
             entity_type="FundingSchedule",
             entity_id=funding_schedule.id,


### PR DESCRIPTION
- Add CurrentUserMiddleware to capture request.user in thread-local
- Wire middleware into MIDDLEWARE setting
- Update signals to read user from thread-local when _current_user not set
- Fix _json_safe to handle datetime/date/time fields (was breaking JSON serialization)
- Remove pytest guards from log_audit/log_workflow_action so signals run in tests
- Add read-only AuditLog admin (no add/change/delete permissions)
- Expose last-10 audit_logs context in FundingSchedule and Payment detail views
- Add audit log table to funding_schedule/payment detail templates
- Add 15-test suite covering CREATE/UPDATE/DELETE logging, middleware user capture, admin immutability, and detail view context
- Fix test_workflow_action_history to clear signal-emitted entries before asserting exact count

## Summary
Explain what this PR does and why.

Fixes #34

## Changes
- [x] Describe key changes (models, views, forms, etc.)
- [x] Add migrations if applicable
- [x] Update tests / add new ones

## Testing
Describe how you tested the changes:
- [ ] Ran `python manage.py check`
- [ ] Verified `runserver` starts successfully
- [ ] Manual browser test on affected routes
- [ ] Unit tests pass (`pytest` or Django test suite)

## Notes
Anything reviewers or Roo Code should be aware of (e.g. partial fixes, TODOs, dependencies).