### PR TITLE
feat(#24): RBAC role-based access control

### DIFF
--- a/src/apps/core/migrations/0003_simplify_officer_roles.py
+++ b/src/apps/core/migrations/0003_simplify_officer_roles.py
@@ -1,0 +1,82 @@
+"""
+Migration: Simplify OfficerRole and GroupType to 5 clean roles.
+
+Old roles mapped to new:
+  PRINCIPAL_OFFICER, PROGRAM_OFFICER, SENIOR_OFFICER → OFFICER
+  DIRECTOR, GM → MANAGER
+  COUNCIL_USER, COUNCIL_MANAGER → unchanged
+  OTHER → READ_ONLY
+"""
+from django.db import migrations, models
+
+
+OLD_TO_NEW = {
+    'PRINCIPAL_OFFICER': 'OFFICER',
+    'PROGRAM_OFFICER': 'OFFICER',
+    'SENIOR_OFFICER': 'OFFICER',
+    'DIRECTOR': 'MANAGER',
+    'GM': 'MANAGER',
+    'OTHER': 'READ_ONLY',
+}
+
+OLD_GROUP_TO_NEW = {
+    'FNC_USER': 'OFFICER',
+    'FNC_MANAGER': 'MANAGER',
+    'OTHER_TEAM_USER': 'OFFICER',
+    'OTHER_TEAM_MANAGER': 'MANAGER',
+}
+
+
+def migrate_roles_forward(apps, schema_editor):
+    Profile = apps.get_model('core', 'Profile')
+    for old, new in OLD_TO_NEW.items():
+        Profile.objects.filter(officer_role=old).update(officer_role=new)
+
+    GroupPermission = apps.get_model('core', 'GroupPermission')
+    for old, new in OLD_GROUP_TO_NEW.items():
+        GroupPermission.objects.filter(group_type=old).update(group_type=new)
+
+
+def migrate_roles_backward(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0002_drop_land_project'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='profile',
+            name='officer_role',
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ('OFFICER', 'Officer'),
+                    ('MANAGER', 'Manager'),
+                    ('COUNCIL_USER', 'Council User'),
+                    ('COUNCIL_MANAGER', 'Council Manager'),
+                    ('READ_ONLY', 'Read Only'),
+                ],
+                help_text='FNC role for the officer',
+                max_length=30,
+            ),
+        ),
+        migrations.AlterField(
+            model_name='grouppermission',
+            name='group_type',
+            field=models.CharField(
+                choices=[
+                    ('OFFICER', 'Officer'),
+                    ('MANAGER', 'Manager'),
+                    ('COUNCIL_USER', 'Council User'),
+                    ('COUNCIL_MANAGER', 'Council Manager'),
+                    ('READ_ONLY', 'Read Only'),
+                ],
+                max_length=30,
+            ),
+        ),
+        migrations.RunPython(migrate_roles_forward, migrate_roles_backward),
+    ]

--- a/src/apps/core/mixins.py
+++ b/src/apps/core/mixins.py
@@ -1,0 +1,113 @@
+"""
+RBAC mixins for view-level access control.
+
+Five roles:
+  OFFICER        — FNC frontline staff, full CRUD on all records
+  MANAGER        — FNC senior staff, same access as Officer (trust-based)
+  COUNCIL_USER   — Council staff, own-council data only, can submit reports/claims
+  COUNCIL_MANAGER— Senior council staff, same scope as Council User
+  READ_ONLY      — Internal audit/finance/executives, read everything, no writes
+
+Council scoping: COUNCIL_USER and COUNCIL_MANAGER see only records belonging
+to their own council. The CouncilScopedMixin enforces this at the queryset level.
+"""
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import PermissionDenied
+
+
+COUNCIL_ROLES = frozenset({'COUNCIL_USER', 'COUNCIL_MANAGER'})
+FNC_ROLES = frozenset({'OFFICER', 'MANAGER'})
+WRITE_ROLES = frozenset({'OFFICER', 'MANAGER'})
+ALL_ROLES = frozenset({'OFFICER', 'MANAGER', 'COUNCIL_USER', 'COUNCIL_MANAGER', 'READ_ONLY'})
+
+
+def get_role(request):
+    """Return the officer_role string for the current user, or None."""
+    try:
+        return request.user.profile.officer_role
+    except Exception:
+        return None
+
+
+class RoleRequiredMixin(LoginRequiredMixin):
+    """
+    Base mixin. Subclasses set `required_roles` to a frozenset of allowed role strings.
+    Raises 403 (not redirect) on role violation.
+    """
+    required_roles = ALL_ROLES
+
+    def dispatch(self, request, *args, **kwargs):
+        response = super().dispatch(request, *args, **kwargs)
+        if not request.user.is_authenticated:
+            return response
+        role = get_role(request)
+        if role not in self.required_roles and not request.user.is_superuser:
+            raise PermissionDenied
+        return response
+
+
+class FNCOnlyMixin(RoleRequiredMixin):
+    """Only FNC staff (Officer or Manager) can access this view."""
+    required_roles = FNC_ROLES
+
+
+class WriteRequiredMixin(RoleRequiredMixin):
+    """Write access: Officer or Manager only. Council and Read-Only roles get 403."""
+    required_roles = WRITE_ROLES
+
+
+class CouncilOrFNCMixin(RoleRequiredMixin):
+    """Any authenticated user with a valid role can access (all 5 roles)."""
+    required_roles = ALL_ROLES
+
+
+class ReadOnlyExcludedMixin(RoleRequiredMixin):
+    """All roles except READ_ONLY — for action views that change state."""
+    required_roles = frozenset({'OFFICER', 'MANAGER', 'COUNCIL_USER', 'COUNCIL_MANAGER'})
+
+
+class CouncilScopedMixin:
+    """
+    Filters list/detail querysets to own council for COUNCIL_USER and COUNCIL_MANAGER.
+    Must be combined with a RoleRequiredMixin subclass.
+
+    Set `council_filter_field` to the queryset lookup path that reaches the council
+    FK (e.g. 'council', 'project__council', 'funding_schedule__project__council').
+    """
+    council_filter_field = 'council'
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        role = get_role(self.request)
+        if role in COUNCIL_ROLES:
+            try:
+                council = self.request.user.profile.council
+                if council is None:
+                    return qs.none()
+                return qs.filter(**{self.council_filter_field: council})
+            except Exception:
+                return qs.none()
+        return qs
+
+    def get_object(self):
+        obj = super().get_object()
+        role = get_role(self.request)
+        if role in COUNCIL_ROLES:
+            try:
+                council = self.request.user.profile.council
+                parts = self.council_filter_field.split('__')
+                val = obj
+                for part in parts:
+                    val = getattr(val, part, None)
+                if val != council:
+                    raise PermissionDenied
+            except PermissionDenied:
+                raise
+            except Exception:
+                raise PermissionDenied
+        return obj
+
+
+class CouncilSubmitMixin(RoleRequiredMixin):
+    """Only council-side roles may submit reports or expense claims."""
+    required_roles = COUNCIL_ROLES

--- a/src/apps/core/models/accounts_models.py
+++ b/src/apps/core/models/accounts_models.py
@@ -9,14 +9,11 @@ class Profile(models.Model):
     User profile extending Django's User with council assignment.
     """
     class OfficerRole(models.TextChoices):
-        PRINCIPAL_OFFICER = 'PRINCIPAL_OFFICER', 'Principal Officer'
-        SENIOR_OFFICER = 'SENIOR_OFFICER', 'Senior Officer'
-        PROGRAM_OFFICER = 'PROGRAM_OFFICER', 'Program Officer'
+        OFFICER = 'OFFICER', 'Officer'
         MANAGER = 'MANAGER', 'Manager'
-        DIRECTOR = 'DIRECTOR', 'Director'
         COUNCIL_USER = 'COUNCIL_USER', 'Council User'
         COUNCIL_MANAGER = 'COUNCIL_MANAGER', 'Council Manager'
-        OTHER = 'OTHER', 'Other'
+        READ_ONLY = 'READ_ONLY', 'Read Only'
 
     user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='profile')
     council = models.ForeignKey(Council, on_delete=models.SET_NULL, null=True, blank=True, related_name='users')
@@ -39,12 +36,11 @@ class GroupPermission(models.Model):
     group = models.OneToOneField(Group, on_delete=models.CASCADE, related_name='fnc_permissions')
 
     class GroupType(models.TextChoices):
-        FNC_USER = 'FNC_USER', 'FNC User'
-        FNC_MANAGER = 'FNC_MANAGER', 'FNC Manager'
+        OFFICER = 'OFFICER', 'Officer'
+        MANAGER = 'MANAGER', 'Manager'
         COUNCIL_USER = 'COUNCIL_USER', 'Council User'
         COUNCIL_MANAGER = 'COUNCIL_MANAGER', 'Council Manager'
-        OTHER_TEAM_USER = 'OTHER_TEAM_USER', 'HPW Other Team User'
-        OTHER_TEAM_MANAGER = 'OTHER_TEAM_MANAGER', 'HPW Other Team Manager'
+        READ_ONLY = 'READ_ONLY', 'Read Only'
 
     group_type = models.CharField(max_length=30, choices=GroupType.choices)
     description = models.TextField(blank=True)
@@ -62,19 +58,17 @@ class GroupPermission(models.Model):
     def save(self, *args, **kwargs):
         if not self.group_type and self.group.name:
             name_lower = self.group.name.lower()
-            if 'fnc manager' in name_lower:
-                self.group_type = self.GroupType.FNC_MANAGER
+            if 'manager' in name_lower and 'council' not in name_lower:
+                self.group_type = self.GroupType.MANAGER
                 self.can_approve_reports = True
                 self.can_approve_payments = True
-            elif 'fnc user' in name_lower:
-                self.group_type = self.GroupType.FNC_USER
+            elif 'officer' in name_lower or 'fnc' in name_lower:
+                self.group_type = self.GroupType.OFFICER
             elif 'council manager' in name_lower:
                 self.group_type = self.GroupType.COUNCIL_MANAGER
-            elif 'council user' in name_lower:
+            elif 'council' in name_lower:
                 self.group_type = self.GroupType.COUNCIL_USER
-            elif 'other team manager' in name_lower:
-                self.group_type = self.GroupType.OTHER_TEAM_MANAGER
-            elif 'other team user' in name_lower:
-                self.group_type = self.GroupType.OTHER_TEAM_USER
+            elif 'read' in name_lower or 'audit' in name_lower or 'finance' in name_lower:
+                self.group_type = self.GroupType.READ_ONLY
 
         super().save(*args, **kwargs)

--- a/src/apps/ui/views/crud_views.py
+++ b/src/apps/ui/views/crud_views.py
@@ -1,8 +1,11 @@
-"""
+﻿"""
 CRUD views for core domain entities using Django class-based views.
 All views require login via LoginRequiredMixin.
 """
-from django.contrib.auth.mixins import LoginRequiredMixin
+from apps.core.mixins import (
+    CouncilOrFNCMixin, CouncilScopedMixin, WriteRequiredMixin,
+    FNCOnlyMixin, CouncilSubmitMixin,
+)
 from django.urls import reverse_lazy
 from django.views.generic import (
     ListView, CreateView, DetailView, UpdateView, DeleteView, View,
@@ -25,14 +28,14 @@ from apps.core.models import (
 # Council
 # ---------------------------------------------------------------------------
 
-class CouncilListView(LoginRequiredMixin, ListView):
+class CouncilListView(CouncilOrFNCMixin, ListView):
     model = Council
     template_name = 'councils/list.html'
     context_object_name = 'councils'
     paginate_by = 50
 
 
-class CouncilCreateView(LoginRequiredMixin, CreateView):
+class CouncilCreateView(WriteRequiredMixin, CreateView):
     model = Council
     template_name = 'crud/form.html'
     fields = ['name', 'region', 'state_electorate', 'federal_electorate',
@@ -47,13 +50,13 @@ class CouncilCreateView(LoginRequiredMixin, CreateView):
         return ctx
 
 
-class CouncilDetailView(LoginRequiredMixin, DetailView):
+class CouncilDetailView(CouncilOrFNCMixin, DetailView):
     model = Council
     template_name = 'councils/detail.html'
     context_object_name = 'council'
 
 
-class CouncilUpdateView(LoginRequiredMixin, UpdateView):
+class CouncilUpdateView(WriteRequiredMixin, UpdateView):
     model = Council
     template_name = 'crud/form.html'
     fields = ['name', 'region', 'state_electorate', 'federal_electorate',
@@ -68,7 +71,7 @@ class CouncilUpdateView(LoginRequiredMixin, UpdateView):
         return ctx
 
 
-class CouncilDeleteView(LoginRequiredMixin, DeleteView):
+class CouncilDeleteView(WriteRequiredMixin, DeleteView):
     model = Council
     template_name = 'crud/confirm_delete.html'
     success_url = reverse_lazy('ui:council_list')
@@ -83,14 +86,14 @@ class CouncilDeleteView(LoginRequiredMixin, DeleteView):
 # Program
 # ---------------------------------------------------------------------------
 
-class ProgramListView(LoginRequiredMixin, ListView):
+class ProgramListView(CouncilOrFNCMixin, ListView):
     model = Program
     template_name = 'programs/list.html'
     context_object_name = 'programs'
     paginate_by = 50
 
 
-class ProgramCreateView(LoginRequiredMixin, CreateView):
+class ProgramCreateView(WriteRequiredMixin, CreateView):
     model = Program
     template_name = 'crud/form.html'
     fields = ['name', 'funding_source', 'funding_source_other', 'budget',
@@ -104,13 +107,13 @@ class ProgramCreateView(LoginRequiredMixin, CreateView):
         return ctx
 
 
-class ProgramDetailView(LoginRequiredMixin, DetailView):
+class ProgramDetailView(CouncilOrFNCMixin, DetailView):
     model = Program
     template_name = 'programs/detail.html'
     context_object_name = 'program'
 
 
-class ProgramUpdateView(LoginRequiredMixin, UpdateView):
+class ProgramUpdateView(WriteRequiredMixin, UpdateView):
     model = Program
     template_name = 'crud/form.html'
     fields = ['name', 'funding_source', 'funding_source_other', 'budget',
@@ -124,7 +127,7 @@ class ProgramUpdateView(LoginRequiredMixin, UpdateView):
         return ctx
 
 
-class ProgramDeleteView(LoginRequiredMixin, DeleteView):
+class ProgramDeleteView(WriteRequiredMixin, DeleteView):
     model = Program
     template_name = 'crud/confirm_delete.html'
     success_url = reverse_lazy('ui:program_list')
@@ -139,7 +142,7 @@ class ProgramDeleteView(LoginRequiredMixin, DeleteView):
 # Project
 # ---------------------------------------------------------------------------
 
-class ProjectCreateView(LoginRequiredMixin, CreateView):
+class ProjectCreateView(WriteRequiredMixin, CreateView):
     model = Project
     template_name = 'crud/form.html'
     fields = ['name', 'council', 'program', 'project_type', 'financial_year',
@@ -153,13 +156,14 @@ class ProjectCreateView(LoginRequiredMixin, CreateView):
         return ctx
 
 
-class ProjectDetailView(LoginRequiredMixin, DetailView):
+class ProjectDetailView(CouncilScopedMixin, CouncilOrFNCMixin, DetailView):
     model = Project
+    council_filter_field = 'council'
     template_name = 'projects/detail.html'
     context_object_name = 'project'
 
 
-class ProjectUpdateView(LoginRequiredMixin, UpdateView):
+class ProjectUpdateView(WriteRequiredMixin, UpdateView):
     model = Project
     template_name = 'crud/form.html'
     fields = ['name', 'council', 'program', 'project_type', 'financial_year',
@@ -173,7 +177,7 @@ class ProjectUpdateView(LoginRequiredMixin, UpdateView):
         return ctx
 
 
-class ProjectDeleteView(LoginRequiredMixin, DeleteView):
+class ProjectDeleteView(WriteRequiredMixin, DeleteView):
     model = Project
     template_name = 'crud/confirm_delete.html'
     success_url = reverse_lazy('ui:projects_list')
@@ -188,14 +192,14 @@ class ProjectDeleteView(LoginRequiredMixin, DeleteView):
 # WorkType
 # ---------------------------------------------------------------------------
 
-class WorkTypeListView(LoginRequiredMixin, ListView):
+class WorkTypeListView(CouncilOrFNCMixin, ListView):
     model = WorkType
     template_name = 'work_types/list.html'
     context_object_name = 'work_types'
     paginate_by = 50
 
 
-class WorkTypeCreateView(LoginRequiredMixin, CreateView):
+class WorkTypeCreateView(WriteRequiredMixin, CreateView):
     model = WorkType
     template_name = 'crud/form.html'
     fields = ['name', 'category', 'has_bedrooms', 'default_bedrooms', 'description', 'is_active']
@@ -208,13 +212,13 @@ class WorkTypeCreateView(LoginRequiredMixin, CreateView):
         return ctx
 
 
-class WorkTypeDetailView(LoginRequiredMixin, DetailView):
+class WorkTypeDetailView(CouncilOrFNCMixin, DetailView):
     model = WorkType
     template_name = 'work_types/detail.html'
     context_object_name = 'work_type'
 
 
-class WorkTypeUpdateView(LoginRequiredMixin, UpdateView):
+class WorkTypeUpdateView(WriteRequiredMixin, UpdateView):
     model = WorkType
     template_name = 'crud/form.html'
     fields = ['name', 'category', 'has_bedrooms', 'default_bedrooms', 'description', 'is_active']
@@ -227,7 +231,7 @@ class WorkTypeUpdateView(LoginRequiredMixin, UpdateView):
         return ctx
 
 
-class WorkTypeDeleteView(LoginRequiredMixin, DeleteView):
+class WorkTypeDeleteView(WriteRequiredMixin, DeleteView):
     model = WorkType
     template_name = 'crud/confirm_delete.html'
     success_url = reverse_lazy('ui:work_type_list')
@@ -242,14 +246,15 @@ class WorkTypeDeleteView(LoginRequiredMixin, DeleteView):
 # FundingSchedule
 # ---------------------------------------------------------------------------
 
-class FundingScheduleListView(LoginRequiredMixin, ListView):
+class FundingScheduleListView(CouncilScopedMixin, CouncilOrFNCMixin, ListView):
     model = FundingSchedule
+    council_filter_field = 'project__council'
     template_name = 'funding_schedules/list.html'
     context_object_name = 'funding_schedules'
     paginate_by = 50
 
 
-class FundingScheduleCreateView(LoginRequiredMixin, CreateView):
+class FundingScheduleCreateView(WriteRequiredMixin, CreateView):
     model = FundingSchedule
     template_name = 'crud/form.html'
     fields = ['project', 'amount', 'contingency', 'payment_split', 'status']
@@ -262,8 +267,9 @@ class FundingScheduleCreateView(LoginRequiredMixin, CreateView):
         return ctx
 
 
-class FundingScheduleDetailView(LoginRequiredMixin, DetailView):
+class FundingScheduleDetailView(CouncilScopedMixin, CouncilOrFNCMixin, DetailView):
     model = FundingSchedule
+    council_filter_field = 'project__council'
     template_name = 'funding_schedules/detail.html'
     context_object_name = 'funding_schedule'
 
@@ -276,7 +282,7 @@ class FundingScheduleDetailView(LoginRequiredMixin, DetailView):
         return ctx
 
 
-class FundingScheduleUpdateView(LoginRequiredMixin, UpdateView):
+class FundingScheduleUpdateView(WriteRequiredMixin, UpdateView):
     model = FundingSchedule
     template_name = 'crud/form.html'
     fields = ['project', 'amount', 'contingency', 'payment_split', 'status']
@@ -289,7 +295,7 @@ class FundingScheduleUpdateView(LoginRequiredMixin, UpdateView):
         return ctx
 
 
-class FundingScheduleDeleteView(LoginRequiredMixin, DeleteView):
+class FundingScheduleDeleteView(WriteRequiredMixin, DeleteView):
     model = FundingSchedule
     template_name = 'crud/confirm_delete.html'
     success_url = reverse_lazy('ui:funding_schedule_list')
@@ -304,7 +310,7 @@ class FundingScheduleDeleteView(LoginRequiredMixin, DeleteView):
 # Variation
 # ---------------------------------------------------------------------------
 
-class VariationCreateView(LoginRequiredMixin, CreateView):
+class VariationCreateView(WriteRequiredMixin, CreateView):
     model = Variation
     template_name = 'crud/form.html'
     fields = ['funding_schedule', 'variation_option', 'status', 'description',
@@ -318,13 +324,14 @@ class VariationCreateView(LoginRequiredMixin, CreateView):
         return ctx
 
 
-class VariationDetailView(LoginRequiredMixin, DetailView):
+class VariationDetailView(CouncilScopedMixin, CouncilOrFNCMixin, DetailView):
     model = Variation
+    council_filter_field = 'council'
     template_name = 'variations/detail.html'
     context_object_name = 'variation'
 
 
-class VariationUpdateView(LoginRequiredMixin, UpdateView):
+class VariationUpdateView(WriteRequiredMixin, UpdateView):
     model = Variation
     template_name = 'crud/form.html'
     fields = ['funding_schedule', 'variation_option', 'status', 'description',
@@ -338,7 +345,7 @@ class VariationUpdateView(LoginRequiredMixin, UpdateView):
         return ctx
 
 
-class VariationDeleteView(LoginRequiredMixin, DeleteView):
+class VariationDeleteView(WriteRequiredMixin, DeleteView):
     model = Variation
     template_name = 'crud/confirm_delete.html'
     success_url = reverse_lazy('ui:variations_list')
@@ -353,13 +360,14 @@ class VariationDeleteView(LoginRequiredMixin, DeleteView):
 # Payment  (nested under project: /ui/projects/<project_pk>/payments/)
 # ---------------------------------------------------------------------------
 
-class PaymentListView(LoginRequiredMixin, ListView):
+class PaymentListView(CouncilScopedMixin, CouncilOrFNCMixin, ListView):
     model = Payment
+    council_filter_field = 'project__council'
     template_name = 'payments/list.html'
     context_object_name = 'payments'
 
     def get_queryset(self):
-        return Payment.objects.filter(project_id=self.kwargs['project_pk'])
+        return super().get_queryset().filter(project_id=self.kwargs['project_pk'])
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
@@ -367,7 +375,7 @@ class PaymentListView(LoginRequiredMixin, ListView):
         return ctx
 
 
-class PaymentCreateView(LoginRequiredMixin, CreateView):
+class PaymentCreateView(WriteRequiredMixin, CreateView):
     model = Payment
     template_name = 'crud/form.html'
     fields = ['project', 'funding_schedule', 'payment_type', 'calculation_type',
@@ -386,8 +394,9 @@ class PaymentCreateView(LoginRequiredMixin, CreateView):
         return ctx
 
 
-class PaymentDetailView(LoginRequiredMixin, DetailView):
+class PaymentDetailView(CouncilScopedMixin, CouncilOrFNCMixin, DetailView):
     model = Payment
+    council_filter_field = 'project__council'
     template_name = 'payments/detail.html'
     context_object_name = 'payment'
 
@@ -400,7 +409,7 @@ class PaymentDetailView(LoginRequiredMixin, DetailView):
         return ctx
 
 
-class PaymentUpdateView(LoginRequiredMixin, UpdateView):
+class PaymentUpdateView(WriteRequiredMixin, UpdateView):
     model = Payment
     template_name = 'crud/form.html'
     fields = ['project', 'funding_schedule', 'payment_type', 'calculation_type',
@@ -416,7 +425,7 @@ class PaymentUpdateView(LoginRequiredMixin, UpdateView):
         return ctx
 
 
-class PaymentDeleteView(LoginRequiredMixin, DeleteView):
+class PaymentDeleteView(WriteRequiredMixin, DeleteView):
     model = Payment
     template_name = 'crud/confirm_delete.html'
 
@@ -433,13 +442,14 @@ class PaymentDeleteView(LoginRequiredMixin, DeleteView):
 # StageReport  (nested under project)
 # ---------------------------------------------------------------------------
 
-class StageReportListView(LoginRequiredMixin, ListView):
+class StageReportListView(CouncilScopedMixin, CouncilOrFNCMixin, ListView):
     model = StageReport
+    council_filter_field = 'project__council'
     template_name = 'stage_reports/list.html'
     context_object_name = 'stage_reports'
 
     def get_queryset(self):
-        return StageReport.objects.filter(project_id=self.kwargs['project_pk'])
+        return super().get_queryset().filter(project_id=self.kwargs['project_pk'])
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
@@ -447,7 +457,7 @@ class StageReportListView(LoginRequiredMixin, ListView):
         return ctx
 
 
-class StageReportCreateView(LoginRequiredMixin, CreateView):
+class StageReportCreateView(WriteRequiredMixin, CreateView):
     model = StageReport
     template_name = 'crud/form.html'
     fields = ['project', 'stage_type', 'status', 'funding_schedule', 'notes']
@@ -465,13 +475,14 @@ class StageReportCreateView(LoginRequiredMixin, CreateView):
         return ctx
 
 
-class StageReportDetailView(LoginRequiredMixin, DetailView):
+class StageReportDetailView(CouncilScopedMixin, CouncilOrFNCMixin, DetailView):
     model = StageReport
+    council_filter_field = 'project__council'
     template_name = 'stage_reports/detail.html'
     context_object_name = 'stage_report'
 
 
-class StageReportUpdateView(LoginRequiredMixin, UpdateView):
+class StageReportUpdateView(WriteRequiredMixin, UpdateView):
     model = StageReport
     template_name = 'crud/form.html'
     fields = ['project', 'stage_type', 'status', 'funding_schedule', 'notes']
@@ -486,7 +497,7 @@ class StageReportUpdateView(LoginRequiredMixin, UpdateView):
         return ctx
 
 
-class StageReportDeleteView(LoginRequiredMixin, DeleteView):
+class StageReportDeleteView(WriteRequiredMixin, DeleteView):
     model = StageReport
     template_name = 'crud/confirm_delete.html'
 
@@ -503,13 +514,14 @@ class StageReportDeleteView(LoginRequiredMixin, DeleteView):
 # QuarterlyReport  (nested under project)
 # ---------------------------------------------------------------------------
 
-class QuarterlyReportListView(LoginRequiredMixin, ListView):
+class QuarterlyReportListView(CouncilScopedMixin, CouncilOrFNCMixin, ListView):
     model = QuarterlyReport
+    council_filter_field = 'project__council'
     template_name = 'quarterly_reports/list.html'
     context_object_name = 'quarterly_reports'
 
     def get_queryset(self):
-        return QuarterlyReport.objects.filter(project_id=self.kwargs['project_pk'])
+        return super().get_queryset().filter(project_id=self.kwargs['project_pk'])
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
@@ -517,7 +529,7 @@ class QuarterlyReportListView(LoginRequiredMixin, ListView):
         return ctx
 
 
-class QuarterlyReportCreateView(LoginRequiredMixin, CreateView):
+class QuarterlyReportCreateView(WriteRequiredMixin, CreateView):
     model = QuarterlyReport
     template_name = 'crud/form.html'
     fields = ['project', 'year', 'quarter', 'status', 'notes']
@@ -535,13 +547,14 @@ class QuarterlyReportCreateView(LoginRequiredMixin, CreateView):
         return ctx
 
 
-class QuarterlyReportDetailView(LoginRequiredMixin, DetailView):
+class QuarterlyReportDetailView(CouncilScopedMixin, CouncilOrFNCMixin, DetailView):
     model = QuarterlyReport
+    council_filter_field = 'project__council'
     template_name = 'quarterly_reports/detail.html'
     context_object_name = 'quarterly_report'
 
 
-class QuarterlyReportUpdateView(LoginRequiredMixin, UpdateView):
+class QuarterlyReportUpdateView(WriteRequiredMixin, UpdateView):
     model = QuarterlyReport
     template_name = 'crud/form.html'
     fields = ['project', 'year', 'quarter', 'status', 'notes']
@@ -556,7 +569,7 @@ class QuarterlyReportUpdateView(LoginRequiredMixin, UpdateView):
         return ctx
 
 
-class QuarterlyReportDeleteView(LoginRequiredMixin, DeleteView):
+class QuarterlyReportDeleteView(WriteRequiredMixin, DeleteView):
     model = QuarterlyReport
     template_name = 'crud/confirm_delete.html'
 
@@ -573,17 +586,18 @@ class QuarterlyReportDeleteView(LoginRequiredMixin, DeleteView):
 # FundingAgreement
 # ---------------------------------------------------------------------------
 
-class FundingAgreementListView(LoginRequiredMixin, ListView):
+class FundingAgreementListView(CouncilScopedMixin, CouncilOrFNCMixin, ListView):
     model = FundingAgreement
+    council_filter_field = 'council'
     template_name = 'funding_agreements/list.html'
     context_object_name = 'agreements'
     paginate_by = 50
 
     def get_queryset(self):
-        return FundingAgreement.objects.select_related('council').order_by('-created_at')
+        return super().get_queryset().select_related('council').order_by('-created_at')
 
 
-class FundingAgreementCreateView(LoginRequiredMixin, CreateView):
+class FundingAgreementCreateView(WriteRequiredMixin, CreateView):
     model = FundingAgreement
     template_name = 'crud/form.html'
     fields = ['council', 'name', 'execution_date', 'status', 'document_uri', 'notes']
@@ -596,13 +610,14 @@ class FundingAgreementCreateView(LoginRequiredMixin, CreateView):
         return ctx
 
 
-class FundingAgreementDetailView(LoginRequiredMixin, DetailView):
+class FundingAgreementDetailView(CouncilScopedMixin, CouncilOrFNCMixin, DetailView):
     model = FundingAgreement
+    council_filter_field = 'council'
     template_name = 'funding_agreements/detail.html'
     context_object_name = 'agreement'
 
     def get_queryset(self):
-        return FundingAgreement.objects.select_related('council')
+        return super().get_queryset().select_related('council')
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
@@ -610,7 +625,7 @@ class FundingAgreementDetailView(LoginRequiredMixin, DetailView):
         return ctx
 
 
-class FundingAgreementUpdateView(LoginRequiredMixin, UpdateView):
+class FundingAgreementUpdateView(WriteRequiredMixin, UpdateView):
     model = FundingAgreement
     template_name = 'crud/form.html'
     fields = ['council', 'name', 'execution_date', 'status', 'document_uri', 'notes']
@@ -623,7 +638,7 @@ class FundingAgreementUpdateView(LoginRequiredMixin, UpdateView):
         return ctx
 
 
-class FundingAgreementDeleteView(LoginRequiredMixin, DeleteView):
+class FundingAgreementDeleteView(WriteRequiredMixin, DeleteView):
     model = FundingAgreement
     template_name = 'crud/confirm_delete.html'
     success_url = reverse_lazy('ui:funding_agreement_list')
@@ -638,17 +653,18 @@ class FundingAgreementDeleteView(LoginRequiredMixin, DeleteView):
 # FundingNotice
 # ---------------------------------------------------------------------------
 
-class FundingNoticeListView(LoginRequiredMixin, ListView):
+class FundingNoticeListView(CouncilScopedMixin, CouncilOrFNCMixin, ListView):
     model = FundingNotice
+    council_filter_field = 'project__council'
     template_name = 'funding_notices/list.html'
     context_object_name = 'notices'
     paginate_by = 50
 
     def get_queryset(self):
-        return FundingNotice.objects.select_related('project').order_by('-issued_date')
+        return super().get_queryset().select_related('project').order_by('-issued_date')
 
 
-class FundingNoticeCreateView(LoginRequiredMixin, CreateView):
+class FundingNoticeCreateView(WriteRequiredMixin, CreateView):
     model = FundingNotice
     template_name = 'crud/form.html'
     fields = ['project', 'capped_amount', 'issued_date', 'notes']
@@ -661,13 +677,14 @@ class FundingNoticeCreateView(LoginRequiredMixin, CreateView):
         return ctx
 
 
-class FundingNoticeDetailView(LoginRequiredMixin, DetailView):
+class FundingNoticeDetailView(CouncilScopedMixin, CouncilOrFNCMixin, DetailView):
     model = FundingNotice
+    council_filter_field = 'project__council'
     template_name = 'funding_notices/detail.html'
     context_object_name = 'notice'
 
     def get_queryset(self):
-        return FundingNotice.objects.select_related('project')
+        return super().get_queryset().select_related('project')
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
@@ -675,7 +692,7 @@ class FundingNoticeDetailView(LoginRequiredMixin, DetailView):
         return ctx
 
 
-class FundingNoticeUpdateView(LoginRequiredMixin, UpdateView):
+class FundingNoticeUpdateView(WriteRequiredMixin, UpdateView):
     model = FundingNotice
     template_name = 'crud/form.html'
     fields = ['project', 'capped_amount', 'issued_date', 'notes']
@@ -688,7 +705,7 @@ class FundingNoticeUpdateView(LoginRequiredMixin, UpdateView):
         return ctx
 
 
-class FundingNoticeDeleteView(LoginRequiredMixin, DeleteView):
+class FundingNoticeDeleteView(WriteRequiredMixin, DeleteView):
     model = FundingNotice
     template_name = 'crud/confirm_delete.html'
     success_url = reverse_lazy('ui:funding_notice_list')
@@ -699,7 +716,7 @@ class FundingNoticeDeleteView(LoginRequiredMixin, DeleteView):
         return ctx
 
 
-class FundingNoticeCloseView(LoginRequiredMixin, View):
+class FundingNoticeCloseView(WriteRequiredMixin, View):
     def post(self, request, pk):
         notice = get_object_or_404(FundingNotice, pk=pk)
         notice.status = FundingNotice.Status.CLOSED
@@ -712,7 +729,7 @@ class FundingNoticeCloseView(LoginRequiredMixin, View):
 # ExpenseClaim  (nested under FundingNotice)
 # ---------------------------------------------------------------------------
 
-class ExpenseClaimCreateView(LoginRequiredMixin, CreateView):
+class ExpenseClaimCreateView(WriteRequiredMixin, CreateView):
     model = ExpenseClaim
     template_name = 'crud/form.html'
     fields = ['amount', 'date_submitted', 'notes']
@@ -734,7 +751,7 @@ class ExpenseClaimCreateView(LoginRequiredMixin, CreateView):
         return ctx
 
 
-class ExpenseClaimUpdateView(LoginRequiredMixin, UpdateView):
+class ExpenseClaimUpdateView(WriteRequiredMixin, UpdateView):
     model = ExpenseClaim
     template_name = 'crud/form.html'
     fields = ['amount', 'date_submitted', 'notes']
@@ -749,7 +766,7 @@ class ExpenseClaimUpdateView(LoginRequiredMixin, UpdateView):
         return ctx
 
 
-class ExpenseClaimDeleteView(LoginRequiredMixin, DeleteView):
+class ExpenseClaimDeleteView(WriteRequiredMixin, DeleteView):
     model = ExpenseClaim
     template_name = 'crud/confirm_delete.html'
 
@@ -762,7 +779,7 @@ class ExpenseClaimDeleteView(LoginRequiredMixin, DeleteView):
         return ctx
 
 
-class ExpenseClaimApproveView(LoginRequiredMixin, View):
+class ExpenseClaimApproveView(FNCOnlyMixin, View):
     def post(self, request, pk):
         from django.utils import timezone
         claim = get_object_or_404(ExpenseClaim, pk=pk)
@@ -793,7 +810,7 @@ class ExpenseClaimApproveView(LoginRequiredMixin, View):
         return redirect('ui:funding_notice_detail', pk=notice.pk)
 
 
-class ExpenseClaimSubmitView(LoginRequiredMixin, View):
+class ExpenseClaimSubmitView(CouncilSubmitMixin, View):
     def post(self, request, pk):
         claim = get_object_or_404(ExpenseClaim, pk=pk)
         if claim.status != ExpenseClaim.Status.DRAFT:
@@ -805,7 +822,7 @@ class ExpenseClaimSubmitView(LoginRequiredMixin, View):
         return redirect('ui:funding_notice_detail', pk=claim.funding_notice_id)
 
 
-class ExpenseClaimRejectView(LoginRequiredMixin, View):
+class ExpenseClaimRejectView(FNCOnlyMixin, View):
     def post(self, request, pk):
         claim = get_object_or_404(ExpenseClaim, pk=pk)
         if claim.status not in (ExpenseClaim.Status.SUBMITTED, ExpenseClaim.Status.APPROVED):
@@ -822,13 +839,14 @@ class ExpenseClaimRejectView(LoginRequiredMixin, View):
 # BriefFinancialApproval  (nested under project)
 # ---------------------------------------------------------------------------
 
-class BriefFinancialApprovalListView(LoginRequiredMixin, ListView):
+class BriefFinancialApprovalListView(CouncilScopedMixin, CouncilOrFNCMixin, ListView):
     model = BriefFinancialApproval
+    council_filter_field = 'project__council'
     template_name = 'brief_financial_approvals/list.html'
     context_object_name = 'approvals'
 
     def get_queryset(self):
-        return BriefFinancialApproval.objects.filter(project_id=self.kwargs['project_pk'])
+        return super().get_queryset().filter(project_id=self.kwargs['project_pk'])
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
@@ -836,7 +854,7 @@ class BriefFinancialApprovalListView(LoginRequiredMixin, ListView):
         return ctx
 
 
-class BriefFinancialApprovalCreateView(LoginRequiredMixin, CreateView):
+class BriefFinancialApprovalCreateView(WriteRequiredMixin, CreateView):
     model = BriefFinancialApproval
     template_name = 'crud/form.html'
     fields = ['funding_amount', 'contingency_amount', 'delegate_level', 'mincor_reference', 'comments']
@@ -856,13 +874,14 @@ class BriefFinancialApprovalCreateView(LoginRequiredMixin, CreateView):
         return ctx
 
 
-class BriefFinancialApprovalDetailView(LoginRequiredMixin, DetailView):
+class BriefFinancialApprovalDetailView(CouncilScopedMixin, CouncilOrFNCMixin, DetailView):
     model = BriefFinancialApproval
+    council_filter_field = 'project__council'
     template_name = 'brief_financial_approvals/detail.html'
     context_object_name = 'bfa'
 
 
-class BriefFinancialApprovalUpdateView(LoginRequiredMixin, UpdateView):
+class BriefFinancialApprovalUpdateView(WriteRequiredMixin, UpdateView):
     model = BriefFinancialApproval
     template_name = 'crud/form.html'
     fields = ['funding_amount', 'contingency_amount', 'delegate_level', 'mincor_reference', 'comments']
@@ -883,7 +902,7 @@ class BriefFinancialApprovalUpdateView(LoginRequiredMixin, UpdateView):
         return ctx
 
 
-class BriefFinancialApprovalDeleteView(LoginRequiredMixin, DeleteView):
+class BriefFinancialApprovalDeleteView(WriteRequiredMixin, DeleteView):
     model = BriefFinancialApproval
     template_name = 'crud/confirm_delete.html'
 
@@ -896,7 +915,7 @@ class BriefFinancialApprovalDeleteView(LoginRequiredMixin, DeleteView):
         return ctx
 
 
-class BriefFinancialApprovalApproveView(LoginRequiredMixin, View):
+class BriefFinancialApprovalApproveView(FNCOnlyMixin, View):
     def post(self, request, project_pk, pk):
         bfa = get_object_or_404(BriefFinancialApproval, pk=pk, project_id=project_pk)
         if bfa.status != BriefFinancialApproval.Status.PENDING:
@@ -910,7 +929,7 @@ class BriefFinancialApprovalApproveView(LoginRequiredMixin, View):
         return redirect('ui:bfa_detail', project_pk=project_pk, pk=pk)
 
 
-class BriefFinancialApprovalRejectView(LoginRequiredMixin, View):
+class BriefFinancialApprovalRejectView(FNCOnlyMixin, View):
     def post(self, request, project_pk, pk):
         bfa = get_object_or_404(BriefFinancialApproval, pk=pk, project_id=project_pk)
         if bfa.status != BriefFinancialApproval.Status.PENDING:
@@ -926,7 +945,7 @@ class BriefFinancialApprovalRejectView(LoginRequiredMixin, View):
 # PaymentRule (issue #19 — read-only; admin-create only)
 # ---------------------------------------------------------------------------
 
-class PaymentRuleListView(LoginRequiredMixin, ListView):
+class PaymentRuleListView(CouncilOrFNCMixin, ListView):
     model = PaymentRule
     template_name = 'payment_rules/list.html'
     context_object_name = 'payment_rules'
@@ -936,7 +955,7 @@ class PaymentRuleListView(LoginRequiredMixin, ListView):
         return PaymentRule.objects.order_by('name', '-version')
 
 
-class PaymentRuleDetailView(LoginRequiredMixin, DetailView):
+class PaymentRuleDetailView(CouncilOrFNCMixin, DetailView):
     model = PaymentRule
     template_name = 'payment_rules/detail.html'
     context_object_name = 'payment_rule'
@@ -956,7 +975,7 @@ class PaymentRuleDetailView(LoginRequiredMixin, DetailView):
 # Approval (issue #15 — system-generated; approve/reject from UI)
 # ---------------------------------------------------------------------------
 
-class ApprovalListView(LoginRequiredMixin, ListView):
+class ApprovalListView(CouncilOrFNCMixin, ListView):
     model = Approval
     template_name = 'approvals/list.html'
     context_object_name = 'approvals'
@@ -981,13 +1000,13 @@ class ApprovalListView(LoginRequiredMixin, ListView):
         return ctx
 
 
-class ApprovalDetailView(LoginRequiredMixin, DetailView):
+class ApprovalDetailView(CouncilOrFNCMixin, DetailView):
     model = Approval
     template_name = 'approvals/detail.html'
     context_object_name = 'approval'
 
 
-class ApprovalApproveView(LoginRequiredMixin, View):
+class ApprovalApproveView(FNCOnlyMixin, View):
     def post(self, request, pk):
         approval = get_object_or_404(Approval, pk=pk)
         if approval.status != Approval.Status.PENDING:
@@ -1001,7 +1020,7 @@ class ApprovalApproveView(LoginRequiredMixin, View):
         return redirect('ui:approval_detail', pk=pk)
 
 
-class ApprovalRejectView(LoginRequiredMixin, View):
+class ApprovalRejectView(FNCOnlyMixin, View):
     def post(self, request, pk):
         approval = get_object_or_404(Approval, pk=pk)
         if approval.status != Approval.Status.PENDING:
@@ -1017,15 +1036,14 @@ class ApprovalRejectView(LoginRequiredMixin, View):
 # Work (issue #18 — nested under project)
 # ---------------------------------------------------------------------------
 
-class WorkListView(LoginRequiredMixin, ListView):
+class WorkListView(CouncilScopedMixin, CouncilOrFNCMixin, ListView):
     model = Work
+    council_filter_field = 'project__council'
     template_name = 'works/list.html'
     context_object_name = 'works'
 
     def get_queryset(self):
-        return Work.objects.filter(
-            project_id=self.kwargs['project_pk']
-        ).select_related('work_type', 'address').order_by('created_at')
+        return super().get_queryset().filter(project_id=self.kwargs['project_pk']).select_related('work_type', 'address').order_by('created_at')
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
@@ -1033,7 +1051,7 @@ class WorkListView(LoginRequiredMixin, ListView):
         return ctx
 
 
-class WorkCreateView(LoginRequiredMixin, CreateView):
+class WorkCreateView(WriteRequiredMixin, CreateView):
     model = Work
     template_name = 'crud/form.html'
     fields = ['work_type', 'work_type_other', 'bedrooms', 'quantity',
@@ -1055,13 +1073,14 @@ class WorkCreateView(LoginRequiredMixin, CreateView):
         return ctx
 
 
-class WorkDetailView(LoginRequiredMixin, DetailView):
+class WorkDetailView(CouncilScopedMixin, CouncilOrFNCMixin, DetailView):
     model = Work
+    council_filter_field = 'project__council'
     template_name = 'works/detail.html'
     context_object_name = 'work'
 
 
-class WorkUpdateView(LoginRequiredMixin, UpdateView):
+class WorkUpdateView(WriteRequiredMixin, UpdateView):
     model = Work
     template_name = 'crud/form.html'
     fields = ['work_type', 'work_type_other', 'bedrooms', 'quantity',
@@ -1077,7 +1096,7 @@ class WorkUpdateView(LoginRequiredMixin, UpdateView):
         return ctx
 
 
-class WorkDeleteView(LoginRequiredMixin, DeleteView):
+class WorkDeleteView(WriteRequiredMixin, DeleteView):
     model = Work
     template_name = 'crud/confirm_delete.html'
 
@@ -1094,7 +1113,7 @@ class WorkDeleteView(LoginRequiredMixin, DeleteView):
 # Address (issue #18 — nested under project)
 # ---------------------------------------------------------------------------
 
-class AddressListView(LoginRequiredMixin, ListView):
+class AddressListView(CouncilOrFNCMixin, ListView):
     model = Address
     template_name = 'addresses/list.html'
     context_object_name = 'addresses'
@@ -1110,7 +1129,7 @@ class AddressListView(LoginRequiredMixin, ListView):
         return ctx
 
 
-class AddressCreateView(LoginRequiredMixin, CreateView):
+class AddressCreateView(WriteRequiredMixin, CreateView):
     model = Address
     template_name = 'crud/form.html'
     fields = ['street', 'suburb', 'lot', 'plan', 'residence_plc_ref']
@@ -1131,13 +1150,13 @@ class AddressCreateView(LoginRequiredMixin, CreateView):
         return ctx
 
 
-class AddressDetailView(LoginRequiredMixin, DetailView):
+class AddressDetailView(CouncilOrFNCMixin, DetailView):
     model = Address
     template_name = 'addresses/detail.html'
     context_object_name = 'address'
 
 
-class AddressUpdateView(LoginRequiredMixin, UpdateView):
+class AddressUpdateView(WriteRequiredMixin, UpdateView):
     model = Address
     template_name = 'crud/form.html'
     fields = ['street', 'suburb', 'lot', 'plan', 'residence_plc_ref']
@@ -1152,7 +1171,7 @@ class AddressUpdateView(LoginRequiredMixin, UpdateView):
         return ctx
 
 
-class AddressDeleteView(LoginRequiredMixin, DeleteView):
+class AddressDeleteView(WriteRequiredMixin, DeleteView):
     model = Address
     template_name = 'crud/confirm_delete.html'
 
@@ -1170,7 +1189,7 @@ class AddressDeleteView(LoginRequiredMixin, DeleteView):
 # DRAFT → READY_FOR_EXECUTION → EXECUTED → ACTIVE → COMPLETED/SUPERSEDED/CANCELLED
 # ---------------------------------------------------------------------------
 
-class FundingScheduleMarkReadyView(LoginRequiredMixin, View):
+class FundingScheduleMarkReadyView(WriteRequiredMixin, View):
     def post(self, request, pk):
         fs = get_object_or_404(FundingSchedule, pk=pk)
         if fs.status != FundingSchedule.Status.DRAFT:
@@ -1182,7 +1201,7 @@ class FundingScheduleMarkReadyView(LoginRequiredMixin, View):
         return redirect('ui:funding_schedule_detail', pk=pk)
 
 
-class FundingScheduleCompleteView(LoginRequiredMixin, View):
+class FundingScheduleCompleteView(WriteRequiredMixin, View):
     def post(self, request, pk):
         fs = get_object_or_404(FundingSchedule, pk=pk)
         if fs.status != FundingSchedule.Status.ACTIVE:
@@ -1194,7 +1213,7 @@ class FundingScheduleCompleteView(LoginRequiredMixin, View):
         return redirect('ui:funding_schedule_detail', pk=pk)
 
 
-class FundingScheduleSupersededView(LoginRequiredMixin, View):
+class FundingScheduleSupersededView(WriteRequiredMixin, View):
     def post(self, request, pk):
         fs = get_object_or_404(FundingSchedule, pk=pk)
         if fs.status in (FundingSchedule.Status.COMPLETED, FundingSchedule.Status.SUPERSEDED, FundingSchedule.Status.CANCELLED):
@@ -1206,7 +1225,7 @@ class FundingScheduleSupersededView(LoginRequiredMixin, View):
         return redirect('ui:funding_schedule_detail', pk=pk)
 
 
-class FundingScheduleCancelView(LoginRequiredMixin, View):
+class FundingScheduleCancelView(WriteRequiredMixin, View):
     def post(self, request, pk):
         fs = get_object_or_404(FundingSchedule, pk=pk)
         if fs.status in (FundingSchedule.Status.COMPLETED, FundingSchedule.Status.SUPERSEDED, FundingSchedule.Status.CANCELLED):
@@ -1223,7 +1242,7 @@ class FundingScheduleCancelView(LoginRequiredMixin, View):
 # PENDING → RECOMMENDED → APPROVED → RELEASED  (or REJECTED at any pre-final step)
 # ---------------------------------------------------------------------------
 
-class PaymentRecommendView(LoginRequiredMixin, View):
+class PaymentRecommendView(WriteRequiredMixin, View):
     def post(self, request, project_pk, pk):
         payment = get_object_or_404(Payment, pk=pk, project_id=project_pk)
         if payment.status != Payment.Status.PENDING:
@@ -1235,7 +1254,7 @@ class PaymentRecommendView(LoginRequiredMixin, View):
         return redirect('ui:payment_detail', project_pk=project_pk, pk=pk)
 
 
-class PaymentApproveView(LoginRequiredMixin, View):
+class PaymentApproveView(FNCOnlyMixin, View):
     def post(self, request, project_pk, pk):
         payment = get_object_or_404(Payment, pk=pk, project_id=project_pk)
         if payment.status != Payment.Status.RECOMMENDED:
@@ -1247,7 +1266,7 @@ class PaymentApproveView(LoginRequiredMixin, View):
         return redirect('ui:payment_detail', project_pk=project_pk, pk=pk)
 
 
-class PaymentReleaseView(LoginRequiredMixin, View):
+class PaymentReleaseView(WriteRequiredMixin, View):
     def post(self, request, project_pk, pk):
         payment = get_object_or_404(Payment, pk=pk, project_id=project_pk)
         if payment.status != Payment.Status.APPROVED:
@@ -1259,7 +1278,7 @@ class PaymentReleaseView(LoginRequiredMixin, View):
         return redirect('ui:payment_detail', project_pk=project_pk, pk=pk)
 
 
-class PaymentRejectView(LoginRequiredMixin, View):
+class PaymentRejectView(FNCOnlyMixin, View):
     def post(self, request, project_pk, pk):
         payment = get_object_or_404(Payment, pk=pk, project_id=project_pk)
         if payment.status in (Payment.Status.RELEASED, Payment.Status.REJECTED):
@@ -1274,7 +1293,7 @@ class PaymentRejectView(LoginRequiredMixin, View):
 # StageReport lifecycle actions (nested under project)
 # ---------------------------------------------------------------------------
 
-class StageReportSubmitView(LoginRequiredMixin, View):
+class StageReportSubmitView(CouncilSubmitMixin, View):
     def post(self, request, project_pk, pk):
         report = get_object_or_404(StageReport, pk=pk, project_id=project_pk)
         if report.status != StageReport.Status.DRAFT:
@@ -1285,7 +1304,7 @@ class StageReportSubmitView(LoginRequiredMixin, View):
         return redirect('ui:stage_report_detail', project_pk=project_pk, pk=pk)
 
 
-class StageReportEndorseView(LoginRequiredMixin, View):
+class StageReportEndorseView(FNCOnlyMixin, View):
     def post(self, request, project_pk, pk):
         report = get_object_or_404(StageReport, pk=pk, project_id=project_pk)
         if report.status != StageReport.Status.SUBMITTED:
@@ -1296,7 +1315,7 @@ class StageReportEndorseView(LoginRequiredMixin, View):
         return redirect('ui:stage_report_detail', project_pk=project_pk, pk=pk)
 
 
-class StageReportAssessView(LoginRequiredMixin, View):
+class StageReportAssessView(FNCOnlyMixin, View):
     def post(self, request, project_pk, pk):
         report = get_object_or_404(StageReport, pk=pk, project_id=project_pk)
         if report.status != StageReport.Status.ENDORSED:
@@ -1307,7 +1326,7 @@ class StageReportAssessView(LoginRequiredMixin, View):
         return redirect('ui:stage_report_detail', project_pk=project_pk, pk=pk)
 
 
-class StageReportApproveView(LoginRequiredMixin, View):
+class StageReportApproveView(FNCOnlyMixin, View):
     def post(self, request, project_pk, pk):
         report = get_object_or_404(StageReport, pk=pk, project_id=project_pk)
         if report.status != StageReport.Status.ASSESSED:
@@ -1322,7 +1341,7 @@ class StageReportApproveView(LoginRequiredMixin, View):
 # VariationItem (nested under Variation)
 # ---------------------------------------------------------------------------
 
-class VariationItemCreateView(LoginRequiredMixin, CreateView):
+class VariationItemCreateView(WriteRequiredMixin, CreateView):
     model = VariationItem
     template_name = 'crud/form.html'
     fields = ['option', 'description', 'funding_schedule', 'council',
@@ -1347,7 +1366,7 @@ class VariationItemCreateView(LoginRequiredMixin, CreateView):
         return ctx
 
 
-class VariationItemUpdateView(LoginRequiredMixin, UpdateView):
+class VariationItemUpdateView(WriteRequiredMixin, UpdateView):
     model = VariationItem
     template_name = 'crud/form.html'
     fields = ['option', 'description', 'funding_schedule', 'council',
@@ -1366,7 +1385,7 @@ class VariationItemUpdateView(LoginRequiredMixin, UpdateView):
         return ctx
 
 
-class VariationItemDeleteView(LoginRequiredMixin, DeleteView):
+class VariationItemDeleteView(WriteRequiredMixin, DeleteView):
     model = VariationItem
     template_name = 'crud/confirm_delete.html'
 
@@ -1379,7 +1398,7 @@ class VariationItemDeleteView(LoginRequiredMixin, DeleteView):
         return ctx
 
 
-class VariationExecuteView(LoginRequiredMixin, View):
+class VariationExecuteView(FNCOnlyMixin, View):
     def post(self, request, pk):
         variation = get_object_or_404(Variation, pk=pk)
         if variation.status not in (Variation.Status.DRAFT, Variation.Status.COUNCIL_SIGNED):
@@ -1395,19 +1414,18 @@ class VariationExecuteView(LoginRequiredMixin, View):
 # WorkFunding / Allocation
 # ---------------------------------------------------------------------------
 
-class WorkFundingListView(LoginRequiredMixin, ListView):
+class WorkFundingListView(CouncilScopedMixin, CouncilOrFNCMixin, ListView):
     model = WorkFunding
+    council_filter_field = 'project__council'
     template_name = 'allocations/list.html'
     context_object_name = 'allocations'
     paginate_by = 50
 
     def get_queryset(self):
-        return WorkFunding.objects.select_related(
-            'funding_schedule', 'project', 'work'
-        ).order_by('funding_schedule', 'id')
+        return super().get_queryset().select_related('funding_schedule', 'project', 'work').order_by('funding_schedule', 'id')
 
 
-class WorkFundingCreateView(LoginRequiredMixin, CreateView):
+class WorkFundingCreateView(WriteRequiredMixin, CreateView):
     model = WorkFunding
     template_name = 'crud/form.html'
     fields = ['funding_schedule', 'project', 'work', 'cost_centre', 'gl_code', 'tax_code', 'amount', 'notes']
@@ -1420,13 +1438,14 @@ class WorkFundingCreateView(LoginRequiredMixin, CreateView):
         return ctx
 
 
-class WorkFundingDetailView(LoginRequiredMixin, DetailView):
+class WorkFundingDetailView(CouncilScopedMixin, CouncilOrFNCMixin, DetailView):
     model = WorkFunding
+    council_filter_field = 'project__council'
     template_name = 'allocations/detail.html'
     context_object_name = 'allocation'
 
 
-class WorkFundingUpdateView(LoginRequiredMixin, UpdateView):
+class WorkFundingUpdateView(WriteRequiredMixin, UpdateView):
     model = WorkFunding
     template_name = 'crud/form.html'
     fields = ['funding_schedule', 'project', 'work', 'cost_centre', 'gl_code', 'tax_code', 'amount', 'notes']
@@ -1439,7 +1458,7 @@ class WorkFundingUpdateView(LoginRequiredMixin, UpdateView):
         return ctx
 
 
-class WorkFundingDeleteView(LoginRequiredMixin, DeleteView):
+class WorkFundingDeleteView(WriteRequiredMixin, DeleteView):
     model = WorkFunding
     template_name = 'crud/confirm_delete.html'
     success_url = reverse_lazy('ui:allocation_list')

--- a/tests/test_bfa_crud.py
+++ b/tests/test_bfa_crud.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Tests for BriefFinancialApproval CRUD views (issue #14).
 """
 import pytest
@@ -12,7 +12,7 @@ from apps.core.models import BriefFinancialApproval, Profile
 def auth_client(council):
     client = Client()
     user = User.objects.create_user(username='bfa_user', password='pass')
-    Profile.objects.create(user=user, council=council, officer_role=Profile.OfficerRole.SENIOR_OFFICER)
+    Profile.objects.create(user=user, council=council, officer_role=Profile.OfficerRole.OFFICER)
     client.force_login(user)
     return client, user
 

--- a/tests/test_funding_views.py
+++ b/tests/test_funding_views.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Funding Views Tests
 Tests for funding schedule create, edit, delete views
 """
@@ -22,7 +22,7 @@ class TestFundingScheduleCreateView:
         Profile.objects.create(
             user=user,
             council=council,
-            officer_role=Profile.OfficerRole.SENIOR_OFFICER
+            officer_role=Profile.OfficerRole.OFFICER
         )
         client.force_login(user)
         return client
@@ -70,7 +70,7 @@ class TestFundingScheduleListView:
         user = User.objects.create_user(username='funding_lister', password='test123')
         Profile.objects.create(
             user=user,
-            officer_role=Profile.OfficerRole.SENIOR_OFFICER
+            officer_role=Profile.OfficerRole.OFFICER
         )
         client.force_login(user)
         return client
@@ -98,7 +98,7 @@ class TestFundingScheduleDeleteView:
         user = User.objects.create_user(username='funding_deleter', password='test123')
         Profile.objects.create(
             user=user,
-            officer_role=Profile.OfficerRole.SENIOR_OFFICER
+            officer_role=Profile.OfficerRole.OFFICER
         )
         client.force_login(user)
         return client
@@ -129,7 +129,7 @@ class TestWorkFundingView:
         user = User.objects.create_user(username='work_funder', password='test123')
         Profile.objects.create(
             user=user,
-            officer_role=Profile.OfficerRole.SENIOR_OFFICER
+            officer_role=Profile.OfficerRole.OFFICER
         )
         client.force_login(user)
         return client
@@ -157,7 +157,7 @@ class TestFundingCalculations:
         user = User.objects.create_user(username='calc_tester', password='test123')
         Profile.objects.create(
             user=user,
-            officer_role=Profile.OfficerRole.PROGRAM_OFFICER
+            officer_role=Profile.OfficerRole.OFFICER
         )
         client.force_login(user)
         return client
@@ -186,7 +186,7 @@ class TestFundingDualTrack:
         user = User.objects.create_user(username='dual_funder', password='test123')
         Profile.objects.create(
             user=user,
-            officer_role=Profile.OfficerRole.SENIOR_OFFICER
+            officer_role=Profile.OfficerRole.OFFICER
         )
         client.force_login(user)
         return client

--- a/tests/test_issue_15_18_19.py
+++ b/tests/test_issue_15_18_19.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Tests for issues #15 (Approval CRUD), #18 (Work & Address CRUD), #19 (PaymentRule read-only).
 """
 import pytest
@@ -12,7 +12,7 @@ from apps.core.models import Approval, Address, PaymentRule, Work, Profile
 def auth_client(council):
     client = Client()
     user = User.objects.create_user(username='crud_user', password='pass')
-    Profile.objects.create(user=user, council=council, officer_role=Profile.OfficerRole.SENIOR_OFFICER)
+    Profile.objects.create(user=user, council=council, officer_role=Profile.OfficerRole.OFFICER)
     client.force_login(user)
     return client, user
 

--- a/tests/test_issue_16_17_20.py
+++ b/tests/test_issue_16_17_20.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Tests for issues #16 (VariationItem CRUD + execute), #17 (WorkFunding/Allocation CRUD),
 #20 (StageReport lifecycle actions: submit/endorse/assess/approve).
 """
@@ -83,7 +83,17 @@ def stage_report(project, funding_schedule):
 def auth_client(council):
     client = Client()
     user = User.objects.create_user(username='test_user_16_17_20', password='pass')
-    Profile.objects.create(user=user, council=council, officer_role=Profile.OfficerRole.SENIOR_OFFICER)
+    Profile.objects.create(user=user, council=council, officer_role=Profile.OfficerRole.OFFICER)
+    client.force_login(user)
+    return client, user
+
+
+@pytest.fixture
+def council_client(council):
+    """Council-side user for submit actions."""
+    client = Client()
+    user = User.objects.create_user(username='council_user_16_17_20', password='pass')
+    Profile.objects.create(user=user, council=council, officer_role=Profile.OfficerRole.COUNCIL_USER)
     client.force_login(user)
     return client, user
 
@@ -94,8 +104,8 @@ def auth_client(council):
 
 @pytest.mark.django_db
 class TestStageReportSubmit:
-    def test_submit_draft_report(self, auth_client, stage_report):
-        client, _ = auth_client
+    def test_submit_draft_report(self, council_client, stage_report):
+        client, _ = council_client
         response = client.post(
             f'/projects/{stage_report.project_id}/stage-reports/{stage_report.pk}/submit/'
         )

--- a/tests/test_issue_21_22.py
+++ b/tests/test_issue_21_22.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Tests for issue #21 (FundingSchedule lifecycle) and #22 (Payment release pipeline).
 """
 import pytest
@@ -63,7 +63,7 @@ def payment(project, funding_schedule):
 def auth_client(council):
     client = Client()
     user = User.objects.create_user(username='lifecycle_user', password='pass')
-    Profile.objects.create(user=user, council=council, officer_role=Profile.OfficerRole.SENIOR_OFFICER)
+    Profile.objects.create(user=user, council=council, officer_role=Profile.OfficerRole.OFFICER)
     client.force_login(user)
     return client, user
 

--- a/tests/test_issue_23_33_35.py
+++ b/tests/test_issue_23_33_35.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Tests for issue #23 (FundingNotice→ExpenseClaim pipeline),
 #33 (Allocation XOR validation), and #35 (document_uri display).
 """
@@ -82,7 +82,7 @@ def funding_schedule(project):
 def auth_client(council):
     client = Client()
     user = User.objects.create_user(username='pipeline_user', password='pass')
-    Profile.objects.create(user=user, council=council, officer_role=Profile.OfficerRole.SENIOR_OFFICER)
+    Profile.objects.create(user=user, council=council, officer_role=Profile.OfficerRole.OFFICER)
     client.force_login(user)
     return client, user
 

--- a/tests/test_issue_24_rbac.py
+++ b/tests/test_issue_24_rbac.py
@@ -1,0 +1,293 @@
+﻿"""
+Tests for Issue #24: Role-based access control.
+
+Covers:
+- RoleRequiredMixin: 403 for wrong role, pass-through for correct role
+- CouncilScopedMixin: council users see only their own council records
+- CouncilSubmitMixin: only council roles can submit reports/claims
+- FNCOnlyMixin: only FNC roles can approve/reject/execute
+- Superuser bypass
+- Unauthenticated redirect to login
+"""
+import pytest
+from decimal import Decimal
+from django.test import Client
+from django.contrib.auth.models import User
+
+from apps.core.models import (
+    Profile, Council, Program, Project, FundingAgreement, StageReport,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_client(role, council=None, username_suffix=""):
+    client = Client()
+    user = User.objects.create_user(
+        username=f"user_{role}_{username_suffix}", password="pass"
+    )
+    Profile.objects.create(user=user, council=council, officer_role=role)
+    client.force_login(user)
+    return client, user
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def council_a():
+    return Council.objects.create(name="Council A", region="North")
+
+
+@pytest.fixture
+def council_b():
+    return Council.objects.create(name="Council B", region="South")
+
+
+@pytest.fixture
+def program():
+    return Program.objects.create(
+        name="Test Program", funding_source="Gov",
+        budget=Decimal("5000000"), gl_code="GL001",
+    )
+
+
+@pytest.fixture
+def agreement_a(council_a):
+    return FundingAgreement.objects.create(council=council_a, status="DRAFT")
+
+
+@pytest.fixture
+def agreement_b(council_b):
+    return FundingAgreement.objects.create(council=council_b, status="DRAFT")
+
+
+@pytest.fixture
+def project_a(council_a, program):
+    return Project.objects.create(
+        council=council_a, program=program,
+        project_type=Project.Type.DWELLING,
+        name="Project A", state=Project.State.PROSPECTIVE,
+    )
+
+
+# ---------------------------------------------------------------------------
+# RoleRequiredMixin - basic gating
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestRoleGating:
+    """Write views return 403 for council and read-only roles."""
+
+    def test_officer_can_access_create_view(self, council_a):
+        client, _ = make_client("OFFICER", council_a, "o1")
+        assert client.get("/councils/create/").status_code == 200
+
+    def test_manager_can_access_create_view(self, council_a):
+        client, _ = make_client("MANAGER", council_a, "m1")
+        assert client.get("/councils/create/").status_code == 200
+
+    def test_read_only_blocked_from_create_view(self, council_a):
+        client, _ = make_client("READ_ONLY", council_a, "ro1")
+        assert client.get("/councils/create/").status_code == 403
+
+    def test_council_user_blocked_from_create_view(self, council_a):
+        client, _ = make_client("COUNCIL_USER", council_a, "cu1")
+        assert client.get("/councils/create/").status_code == 403
+
+    def test_council_manager_blocked_from_create_view(self, council_a):
+        client, _ = make_client("COUNCIL_MANAGER", council_a, "cm1")
+        assert client.get("/councils/create/").status_code == 403
+
+    def test_unauthenticated_redirects_to_login(self):
+        response = Client().get("/councils/create/")
+        assert response.status_code == 302
+        assert "/accounts/login/" in response["Location"]
+
+    def test_superuser_bypasses_role_check(self):
+        client = Client()
+        su = User.objects.create_superuser(username="su_rbac24", password="pass")
+        client.force_login(su)
+        assert client.get("/councils/create/").status_code == 200
+
+    def test_user_without_profile_blocked(self):
+        client = Client()
+        user = User.objects.create_user(username="no_profile_24", password="pass")
+        client.force_login(user)
+        assert client.get("/councils/create/").status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Read views - all roles can access
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestReadAccess:
+    """All authenticated roles can read list/detail views."""
+
+    def test_officer_can_list_councils(self, council_a):
+        client, _ = make_client("OFFICER", council_a, "o2")
+        assert client.get("/councils/").status_code == 200
+
+    def test_read_only_can_list_councils(self, council_a):
+        client, _ = make_client("READ_ONLY", council_a, "ro2")
+        assert client.get("/councils/").status_code == 200
+
+    def test_council_user_can_list_councils(self, council_a):
+        client, _ = make_client("COUNCIL_USER", council_a, "cu2")
+        assert client.get("/councils/").status_code == 200
+
+    def test_council_manager_can_list_councils(self, council_a):
+        client, _ = make_client("COUNCIL_MANAGER", council_a, "cm2")
+        assert client.get("/councils/").status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# CouncilScopedMixin - data isolation
+# Uses FundingAgreementListView (/funding-agreements/) which has council_filter_field='council'
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestCouncilScoping:
+    """Council users see only records belonging to their own council."""
+
+    def test_council_user_sees_own_agreements(self, agreement_a, agreement_b, council_a):
+        client, _ = make_client("COUNCIL_USER", council_a, "cu3")
+        response = client.get("/funding-agreements/")
+        ids = [a.pk for a in response.context["object_list"]]
+        assert agreement_a.pk in ids
+        assert agreement_b.pk not in ids
+
+    def test_council_manager_sees_own_agreements(self, agreement_a, agreement_b, council_b):
+        client, _ = make_client("COUNCIL_MANAGER", council_b, "cm3")
+        response = client.get("/funding-agreements/")
+        ids = [a.pk for a in response.context["object_list"]]
+        assert agreement_b.pk in ids
+        assert agreement_a.pk not in ids
+
+    def test_officer_sees_all_agreements(self, agreement_a, agreement_b, council_a):
+        client, _ = make_client("OFFICER", council_a, "o3")
+        response = client.get("/funding-agreements/")
+        ids = [a.pk for a in response.context["object_list"]]
+        assert agreement_a.pk in ids
+        assert agreement_b.pk in ids
+
+    def test_read_only_sees_all_agreements(self, agreement_a, agreement_b, council_a):
+        client, _ = make_client("READ_ONLY", council_a, "ro3")
+        response = client.get("/funding-agreements/")
+        ids = [a.pk for a in response.context["object_list"]]
+        assert agreement_a.pk in ids
+        assert agreement_b.pk in ids
+
+    def test_council_user_without_council_sees_nothing(self, agreement_a):
+        client, _ = make_client("COUNCIL_USER", None, "cu4")
+        response = client.get("/funding-agreements/")
+        assert list(response.context["object_list"]) == []
+
+    def test_council_user_cannot_access_other_council_agreement(self, agreement_b, council_a):
+        """Council A user trying to access Council B's agreement gets 403 or 404."""
+        client, _ = make_client("COUNCIL_USER", council_a, "cu5")
+        response = client.get(f"/funding-agreements/{agreement_b.pk}/")
+        assert response.status_code in (403, 404)
+
+    def test_officer_can_access_any_agreement(self, agreement_b, council_a):
+        client, _ = make_client("OFFICER", council_a, "o3b")
+        response = client.get(f"/funding-agreements/{agreement_b.pk}/")
+        assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# CouncilSubmitMixin - council-only submit
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestCouncilSubmitGating:
+    """Submit views: council roles allowed, FNC and READ_ONLY get 403."""
+
+    @pytest.fixture
+    def stage_report(self, project_a):
+        return StageReport.objects.create(
+            project=project_a, stage_type="STAGE1",
+            status=StageReport.Status.DRAFT,
+        )
+
+    def test_council_user_can_submit_report(self, stage_report, council_a):
+        client, _ = make_client("COUNCIL_USER", council_a, "cu6")
+        response = client.post(
+            f"/projects/{stage_report.project_id}/stage-reports/{stage_report.pk}/submit/"
+        )
+        assert response.status_code == 302
+        stage_report.refresh_from_db()
+        assert stage_report.status == StageReport.Status.SUBMITTED
+
+    def test_officer_cannot_submit_report(self, stage_report, council_a):
+        client, _ = make_client("OFFICER", council_a, "o4")
+        assert client.post(
+            f"/projects/{stage_report.project_id}/stage-reports/{stage_report.pk}/submit/"
+        ).status_code == 403
+
+    def test_read_only_cannot_submit_report(self, stage_report, council_a):
+        client, _ = make_client("READ_ONLY", council_a, "ro4")
+        assert client.post(
+            f"/projects/{stage_report.project_id}/stage-reports/{stage_report.pk}/submit/"
+        ).status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# FNCOnlyMixin - approve/endorse/execute
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestFNCOnlyGating:
+    """Approval/endorse/execute views: only OFFICER and MANAGER."""
+
+    @pytest.fixture
+    def stage_report(self, project_a):
+        return StageReport.objects.create(
+            project=project_a, stage_type="STAGE1",
+            status=StageReport.Status.SUBMITTED,
+        )
+
+    def test_officer_can_endorse_report(self, stage_report, council_a):
+        client, _ = make_client("OFFICER", council_a, "o5")
+        assert client.post(
+            f"/projects/{stage_report.project_id}/stage-reports/{stage_report.pk}/endorse/"
+        ).status_code == 302
+
+    def test_manager_can_endorse_report(self, stage_report, council_a):
+        client, _ = make_client("MANAGER", council_a, "m2")
+        assert client.post(
+            f"/projects/{stage_report.project_id}/stage-reports/{stage_report.pk}/endorse/"
+        ).status_code == 302
+
+    def test_council_user_cannot_endorse_report(self, stage_report, council_a):
+        client, _ = make_client("COUNCIL_USER", council_a, "cu7")
+        assert client.post(
+            f"/projects/{stage_report.project_id}/stage-reports/{stage_report.pk}/endorse/"
+        ).status_code == 403
+
+    def test_read_only_cannot_endorse_report(self, stage_report, council_a):
+        client, _ = make_client("READ_ONLY", council_a, "ro5")
+        assert client.post(
+            f"/projects/{stage_report.project_id}/stage-reports/{stage_report.pk}/endorse/"
+        ).status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# OfficerRole enum
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestOfficerRoleEnum:
+
+    def test_exactly_five_roles(self):
+        values = {r.value for r in Profile.OfficerRole}
+        assert values == {"OFFICER", "MANAGER", "COUNCIL_USER", "COUNCIL_MANAGER", "READ_ONLY"}
+
+    def test_old_roles_removed(self):
+        values = {r.value for r in Profile.OfficerRole}
+        for removed in ["SENIOR_OFFICER", "PROGRAM_OFFICER", "PRINCIPAL_OFFICER", "DIRECTOR", "GM", "OTHER"]:
+            assert removed not in values

--- a/tests/test_land_crud.py
+++ b/tests/test_land_crud.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Tests for Land infrastructure CRUD views: LandTenure, DevelopmentApplication (issue #31).
 
 LandProject is not a separate model — land projects are Project(project_type='LAND').
@@ -13,7 +13,7 @@ from apps.core.models import DevelopmentApplication, LandTenure, Profile
 def auth_client(council):
     client = Client()
     user = User.objects.create_user(username='land_user', password='pass')
-    Profile.objects.create(user=user, council=council, officer_role=Profile.OfficerRole.SENIOR_OFFICER)
+    Profile.objects.create(user=user, council=council, officer_role=Profile.OfficerRole.OFFICER)
     client.force_login(user)
     return client, user
 


### PR DESCRIPTION
## Summary

- Simplifies officer roles from 7 to 5: `OFFICER`, `MANAGER`, `COUNCIL_USER`, `COUNCIL_MANAGER`, `READ_ONLY`
- Adds `src/apps/core/mixins.py` with `RoleRequiredMixin`, `FNCOnlyMixin`, `WriteRequiredMixin`, `CouncilOrFNCMixin`, `CouncilSubmitMixin`, `CouncilScopedMixin`
- Wires all 106 views in `crud_views.py` to appropriate role mixins; fixes 10 `get_queryset()` overrides that bypassed council scoping
- Migration `0003_simplify_officer_roles.py` maps old roles forward (PRINCIPAL_OFFICER/PROGRAM_OFFICER/SENIOR_OFFICER→OFFICER, DIRECTOR/GM→MANAGER, OTHER→READ_ONLY)
- 28 new RBAC tests covering role gating, read access, council scoping, submit gating, and FNC-only actions

## Test plan

- [ ] `pytest tests/test_issue_24_rbac.py` — all 28 pass
- [ ] Full suite: 494 passed, 17 skipped, 3 xfailed, 0 failures
- [ ] Council user cannot access another council's records (403/404)
- [ ] READ_ONLY user gets 403 on any write/delete/action endpoint
- [ ] Superuser bypasses all role checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)