### PR TITLE
feat(#25,#26,#27): dashboard — traceability, projects board, cashflow forecast

### DIFF
--- a/src/apps/ui/templates/dashboard/cashflow.html
+++ b/src/apps/ui/templates/dashboard/cashflow.html
@@ -1,97 +1,199 @@
 {% extends "base.html" %}
 {% load static %}
 
-{% block title %}Cashflow Forecast - RICD{% endblock %}
+{% block title %}Cashflow Forecast — RICD{% endblock %}
 
 {% block content %}
-<div class="container-fluid mt-5">
-    <div class="row mb-4">
-        <div class="col-md-12">
-            <h1>Cashflow Forecast</h1>
-            <p class="text-muted">Forecast vs actual payments by program and fiscal year</p>
-        </div>
+<div class="container-fluid mt-4">
+  <div class="d-flex align-items-center justify-content-between mb-3">
+    <div>
+      <h1 class="mb-0">Cashflow Forecast</h1>
+      <p class="text-muted mb-0">Planned vs actual payment releases by month</p>
     </div>
+    <a href="{% url 'ui:dashboard' %}" class="btn btn-outline-secondary btn-sm">← Dashboard</a>
+  </div>
 
-    <!-- Summary Cards -->
-    <div class="row mb-4">
-        <div class="col-md-4">
-            <div class="card bg-light">
-                <div class="card-body">
-                    <h5 class="card-title text-muted">Total Forecast</h5>
-                    <p class="card-text display-4">${{ total_forecast|floatformat:0 }}</p>
-                </div>
-            </div>
-        </div>
-        <div class="col-md-4">
-            <div class="card bg-light">
-                <div class="card-body">
-                    <h5 class="card-title text-muted">Released (Actual)</h5>
-                    <p class="card-text display-4">${{ actual_payments|floatformat:0 }}</p>
-                </div>
-            </div>
-        </div>
-        <div class="col-md-4">
-            <div class="card bg-light">
-                <div class="card-body">
-                    <h5 class="card-title text-muted">Remaining</h5>
-                    <p class="card-text display-4">${{ remaining|floatformat:0 }}</p>
-                </div>
-            </div>
-        </div>
+  <!-- Filters -->
+  <form method="get" class="row g-2 mb-4">
+    <div class="col-auto">
+      <select name="program" class="form-select form-select-sm" onchange="this.form.submit()">
+        <option value="">All Programs</option>
+        {% for prog in programs %}
+          <option value="{{ prog.pk }}" {% if selected_program == prog.pk|stringformat:"s" %}selected{% endif %}>{{ prog.name }}</option>
+        {% endfor %}
+      </select>
     </div>
+    <div class="col-auto">
+      <select name="council" class="form-select form-select-sm" onchange="this.form.submit()">
+        <option value="">All Councils</option>
+        {% for c in councils %}
+          <option value="{{ c.pk }}" {% if selected_council == c.pk|stringformat:"s" %}selected{% endif %}>{{ c.name }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    {% if selected_program or selected_council %}
+    <div class="col-auto">
+      <a href="{% url 'ui:cashflow' %}" class="btn btn-outline-secondary btn-sm">Clear</a>
+    </div>
+    {% endif %}
+  </form>
 
-    <!-- Cashflow by Program -->
-    <div class="row mb-4">
-        <div class="col-md-12">
-            <div class="card">
-                <div class="card-header">
-                    <h5 class="mb-0">Cashflow by Program</h5>
-                </div>
-                {% if by_program %}
-                <div class="table-responsive">
-                    <table class="table table-hover mb-0">
-                        <thead class="table-light">
-                            <tr>
-                                <th>Program</th>
-                                <th class="text-right">Forecast</th>
-                                <th class="text-right">Released</th>
-                                <th class="text-right">Remaining</th>
-                                <th class="text-right">Drawdown %</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for item in by_program %}
-                            <tr>
-                                <td>{{ item.program.name }}</td>
-                                <td class="text-right">${{ item.forecast|floatformat:0 }}</td>
-                                <td class="text-right">${{ item.actual|floatformat:0 }}</td>
-                                <td class="text-right">${{ item.remaining|floatformat:0 }}</td>
-                                <td class="text-right">
-                                    {% if item.drawdown_percent %}
-                                        {{ item.drawdown_percent|floatformat:1 }}%
-                                    {% else %}
-                                        N/A
-                                    {% endif %}
-                                </td>
-                            </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-                {% else %}
-                <div class="card-body">
-                    <p class="text-muted">No cashflow data available.</p>
-                </div>
-                {% endif %}
-            </div>
+  <!-- Summary Cards -->
+  <div class="row mb-4">
+    <div class="col-md-4">
+      <div class="card bg-light">
+        <div class="card-body">
+          <h6 class="card-title text-muted">Total in Pipeline</h6>
+          <p class="card-text fs-4 fw-semibold">${{ total_forecast|floatformat:0 }}</p>
+          <small class="text-muted">Approved + Released + Reconciled</small>
         </div>
+      </div>
     </div>
+    <div class="col-md-4">
+      <div class="card bg-light">
+        <div class="card-body">
+          <h6 class="card-title text-muted">Released (Actual)</h6>
+          <p class="card-text fs-4 fw-semibold text-success">${{ total_released|floatformat:0 }}</p>
+          <small class="text-muted">Released + Reconciled</small>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="card bg-light">
+        <div class="card-body">
+          <h6 class="card-title text-muted">Remaining</h6>
+          <p class="card-text fs-4 fw-semibold text-warning">${{ remaining|floatformat:0 }}</p>
+          <small class="text-muted">Yet to be released</small>
+        </div>
+      </div>
+    </div>
+  </div>
 
-    <!-- Back Link -->
-    <div class="row">
-        <div class="col-md-12">
-            <a href="{% url 'ui:dashboard' %}" class="btn btn-outline-primary">Back to Dashboard</a>
-        </div>
+  <!-- Bar chart (planned vs actual by month) -->
+  {% if chart_labels != "[]" %}
+  <div class="card mb-4">
+    <div class="card-header">
+      <h6 class="mb-0">Monthly Payment Profile</h6>
     </div>
+    <div class="card-body">
+      <canvas id="cashflowChart" height="80"></canvas>
+    </div>
+  </div>
+  {% endif %}
+
+  <!-- By Program table -->
+  {% if by_program %}
+  <div class="card mb-4">
+    <div class="card-header"><h6 class="mb-0">Summary by Program</h6></div>
+    <div class="table-responsive">
+      <table class="table table-hover mb-0">
+        <thead class="table-light">
+          <tr>
+            <th>Program</th>
+            <th class="text-end">Pipeline</th>
+            <th class="text-end">Released</th>
+            <th class="text-end">Remaining</th>
+            <th class="text-end">Drawdown %</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for item in by_program %}
+          {% if item.forecast %}
+          <tr>
+            <td>{{ item.program.name }}</td>
+            <td class="text-end">${{ item.forecast|floatformat:0 }}</td>
+            <td class="text-end text-success">${{ item.actual|floatformat:0 }}</td>
+            <td class="text-end text-warning">${{ item.remaining|floatformat:0 }}</td>
+            <td class="text-end">
+              <div class="d-flex align-items-center justify-content-end gap-2">
+                <div class="progress flex-grow-1" style="height:6px;max-width:80px;">
+                  <div class="progress-bar bg-success" style="width:{{ item.drawdown_percent }}%;"></div>
+                </div>
+                {{ item.drawdown_percent }}%
+              </div>
+            </td>
+          </tr>
+          {% endif %}
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  {% endif %}
+
+  <!-- Payment breakdown table -->
+  {% if payments %}
+  <div class="card mb-4">
+    <div class="card-header"><h6 class="mb-0">Payment Breakdown</h6></div>
+    <div class="table-responsive">
+      <table class="table table-sm table-hover mb-0">
+        <thead class="table-light">
+          <tr>
+            <th>Project</th>
+            <th>Schedule</th>
+            <th>Type</th>
+            <th>Status</th>
+            <th>Release Date</th>
+            <th class="text-end">Amount</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for pmt in payments %}
+          <tr>
+            <td>
+              <a href="{% url 'ui:project_detail' pk=pmt.project.pk %}">{{ pmt.project.name }}</a>
+              <small class="text-muted d-block">{{ pmt.project.council.name }}</small>
+            </td>
+            <td>
+              {% if pmt.funding_schedule %}
+              <a href="{% url 'ui:funding_schedule_detail' pk=pmt.funding_schedule.pk %}">FS#{{ pmt.funding_schedule.schedule_number }}</a>
+              {% else %}—{% endif %}
+            </td>
+            <td>{{ pmt.get_payment_type_display }}</td>
+            <td>
+              <span class="badge {% if pmt.status == 'RELEASED' or pmt.status == 'RECONCILED' %}bg-success{% elif pmt.status == 'APPROVED' %}bg-primary{% else %}bg-secondary{% endif %}">
+                {{ pmt.get_status_display }}
+              </span>
+            </td>
+            <td>{{ pmt.release_date|default:"—" }}</td>
+            <td class="text-end">${{ pmt.amount|floatformat:0 }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  {% else %}
+  <div class="alert alert-light border">No approved/released payments match the current filter.</div>
+  {% endif %}
+
 </div>
+
+{% if chart_labels != "[]" %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+<script>
+(function() {
+  const labels = {{ chart_labels|safe }};
+  const planned = {{ chart_planned|safe }};
+  const actual  = {{ chart_actual|safe }};
+  new Chart(document.getElementById('cashflowChart'), {
+    type: 'bar',
+    data: {
+      labels: labels,
+      datasets: [
+        {label: 'Planned (Approved)', data: planned, backgroundColor: 'rgba(13,110,253,0.5)', borderColor: 'rgba(13,110,253,1)', borderWidth: 1},
+        {label: 'Actual (Released/Reconciled)', data: actual, backgroundColor: 'rgba(25,135,84,0.5)', borderColor: 'rgba(25,135,84,1)', borderWidth: 1},
+      ]
+    },
+    options: {
+      responsive: true,
+      plugins: {legend: {position: 'top'}},
+      scales: {
+        y: {beginAtZero: true, ticks: {callback: v => '$' + v.toLocaleString()}}
+      }
+    }
+  });
+})();
+</script>
+{% endif %}
 {% endblock %}

--- a/src/apps/ui/templates/dashboard/projects_board.html
+++ b/src/apps/ui/templates/dashboard/projects_board.html
@@ -1,0 +1,90 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}Project Status Board — RICD{% endblock %}
+
+{% block content %}
+<div class="container-fluid mt-4">
+  <div class="d-flex align-items-center justify-content-between mb-3">
+    <div>
+      <h1 class="mb-0">Project Status Board</h1>
+      <p class="text-muted mb-0">{{ total_projects }} project{{ total_projects|pluralize }} across all stages</p>
+    </div>
+    <a href="{% url 'ui:dashboard' %}" class="btn btn-outline-secondary btn-sm">← Dashboard</a>
+  </div>
+
+  <!-- Filters -->
+  <form method="get" class="row g-2 mb-4">
+    <div class="col-auto">
+      <select name="program" class="form-select form-select-sm" onchange="this.form.submit()">
+        <option value="">All Programs</option>
+        {% for prog in programs %}
+          <option value="{{ prog.pk }}" {% if selected_program == prog.pk|stringformat:"s" %}selected{% endif %}>{{ prog.name }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-auto">
+      <select name="council" class="form-select form-select-sm" onchange="this.form.submit()">
+        <option value="">All Councils</option>
+        {% for c in councils %}
+          <option value="{{ c.pk }}" {% if selected_council == c.pk|stringformat:"s" %}selected{% endif %}>{{ c.name }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-auto">
+      <select name="financial_year" class="form-select form-select-sm" onchange="this.form.submit()">
+        <option value="">All Years</option>
+        {% for fy in financial_years %}
+          <option value="{{ fy }}" {% if selected_year == fy %}selected{% endif %}>{{ fy }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    {% if selected_program or selected_council or selected_year %}
+    <div class="col-auto">
+      <a href="{% url 'ui:projects_board' %}" class="btn btn-outline-secondary btn-sm">Clear</a>
+    </div>
+    {% endif %}
+  </form>
+
+  <!-- Kanban columns -->
+  <div class="d-flex gap-3 overflow-auto pb-3" style="min-height: 70vh;">
+    {% for col in columns %}
+    <div class="flex-shrink-0" style="width: 220px;">
+      <div class="card h-100 border-0 bg-light">
+        <div class="card-header bg-secondary text-white py-2 px-3 d-flex justify-content-between align-items-center">
+          <strong class="small">{{ col.label }}</strong>
+          <span class="badge bg-white text-secondary">{{ col.count }}</span>
+        </div>
+        <div class="card-body p-2 overflow-auto" style="max-height: 65vh;">
+          {% for card in col.projects %}
+          <a href="{% url 'ui:project_detail' pk=card.project.pk %}" class="text-decoration-none">
+            <div class="card mb-2 shadow-sm {% if card.overdue %}border-danger{% endif %}">
+              <div class="card-body p-2">
+                <p class="fw-semibold small mb-1 text-dark">{{ card.project.name }}</p>
+                <p class="text-muted small mb-1">{{ card.project.council.name }}</p>
+                <p class="text-muted small mb-1">{{ card.project.program.name }}</p>
+                {% if card.total_funding %}
+                <p class="small mb-1 text-success fw-semibold">${{ card.total_funding|floatformat:0 }}</p>
+                {% endif %}
+                {% if card.days_left is not None %}
+                  {% if card.overdue %}
+                  <span class="badge bg-danger small">{{ card.days_left|cut:"-" }}d overdue</span>
+                  {% elif card.days_left <= 30 %}
+                  <span class="badge bg-warning text-dark small">{{ card.days_left }}d left</span>
+                  {% else %}
+                  <span class="badge bg-light text-muted small">{{ card.days_left }}d left</span>
+                  {% endif %}
+                {% endif %}
+              </div>
+            </div>
+          </a>
+          {% empty %}
+          <p class="text-muted small text-center mt-3">No projects</p>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/src/apps/ui/templates/dashboard/traceability.html
+++ b/src/apps/ui/templates/dashboard/traceability.html
@@ -1,0 +1,191 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}Financial Traceability — RICD{% endblock %}
+
+{% block content %}
+<div class="container-fluid mt-4">
+  <div class="d-flex align-items-center justify-content-between mb-3">
+    <div>
+      <h1 class="mb-0">Financial Traceability</h1>
+      <p class="text-muted mb-0">Follow the money — Council → Agreement → Schedule → Payments</p>
+    </div>
+    <a href="{% url 'ui:dashboard' %}" class="btn btn-outline-secondary btn-sm">← Dashboard</a>
+  </div>
+
+  <!-- Council picker -->
+  <form method="get" class="row g-2 mb-4">
+    <div class="col-auto">
+      <select name="council" class="form-select" onchange="this.form.submit()">
+        <option value="">— Select a Council —</option>
+        {% for c in councils %}
+          <option value="{{ c.pk }}" {% if selected_council and selected_council.pk == c.pk %}selected{% endif %}>{{ c.name }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-auto">
+      <button type="submit" class="btn btn-primary">View</button>
+    </div>
+    {% if selected_council %}
+    <div class="col-auto">
+      <a href="{% url 'ui:traceability' %}" class="btn btn-outline-secondary">Clear</a>
+    </div>
+    {% endif %}
+  </form>
+
+  {% if selected_council %}
+
+  <!-- Grand total banner -->
+  <div class="row mb-4">
+    <div class="col-md-3">
+      <div class="card bg-light">
+        <div class="card-body py-2">
+          <small class="text-muted d-block">Council</small>
+          <strong>{{ selected_council.name }}</strong>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="card bg-light">
+        <div class="card-body py-2">
+          <small class="text-muted d-block">Total Allocated</small>
+          <strong>${{ grand_total|floatformat:0 }}</strong>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="card bg-light">
+        <div class="card-body py-2">
+          <small class="text-muted d-block">Total Released</small>
+          <strong>${{ grand_paid|floatformat:0 }}</strong>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="card bg-light">
+        <div class="card-body py-2">
+          <small class="text-muted d-block">% Expended</small>
+          <strong>{{ grand_pct }}%</strong>
+          <div class="progress mt-1" style="height:6px;">
+            <div class="progress-bar" style="width:{{ grand_pct }}%;"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {% if chain %}
+  {% for agreement_row in chain %}
+  <!-- Level 1: Funding Agreement -->
+  <div class="card mb-3">
+    <div class="card-header d-flex justify-content-between align-items-center py-2">
+      <div>
+        <strong>{{ agreement_row.agreement.name }}</strong>
+        <span class="badge bg-secondary ms-2">{{ agreement_row.agreement.get_status_display }}</span>
+        {% if agreement_row.agreement.execution_date %}
+        <small class="text-muted ms-2">Executed {{ agreement_row.agreement.execution_date }}</small>
+        {% endif %}
+      </div>
+      <div class="text-end small">
+        <span class="text-muted">${{ agreement_row.total|floatformat:0 }} total</span>
+        &nbsp;·&nbsp;
+        <span class="text-success">${{ agreement_row.paid|floatformat:0 }} released</span>
+        &nbsp;·&nbsp;
+        <strong>{{ agreement_row.pct_expended }}%</strong>
+        <div class="progress mt-1" style="height:4px;width:120px;display:inline-block;vertical-align:middle;">
+          <div class="progress-bar bg-success" style="width:{{ agreement_row.pct_expended }}%;"></div>
+        </div>
+      </div>
+    </div>
+    <div class="card-body p-0">
+      {% for srow in agreement_row.schedules %}
+      <!-- Level 2: Funding Schedule -->
+      <div class="border-bottom px-3 py-2 bg-light">
+        <div class="d-flex justify-content-between align-items-start">
+          <div>
+            <a href="{% url 'ui:funding_schedule_detail' pk=srow.schedule.pk %}" class="fw-semibold text-decoration-none">
+              FS#{{ srow.schedule.schedule_number }} — {{ srow.schedule.project.name }}
+            </a>
+            <span class="badge bg-info text-dark ms-2 small">{{ srow.schedule.get_status_display }}</span>
+          </div>
+          <div class="text-end small">
+            <span class="text-muted">${{ srow.schedule.total_funding|floatformat:0 }}</span>
+            &nbsp;·&nbsp;
+            <span class="text-success">${{ srow.paid|floatformat:0 }} released</span>
+            &nbsp;·&nbsp;
+            <span class="text-warning">${{ srow.remaining|floatformat:0 }} remaining</span>
+            &nbsp;·&nbsp;
+            <strong>{{ srow.pct_expended }}%</strong>
+          </div>
+        </div>
+      </div>
+
+      <!-- Level 3: Allocations -->
+      {% if srow.allocations %}
+      <div class="px-4 py-1">
+        <small class="text-muted fw-semibold">Allocations</small>
+        <table class="table table-sm table-borderless mb-1">
+          <thead>
+            <tr class="text-muted small">
+              <th>Target</th><th>Cost Centre</th><th class="text-end">Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for alloc in srow.allocations %}
+            <tr class="small">
+              <td>{% if alloc.project %}{{ alloc.project.name }}{% elif alloc.work %}Work #{{ alloc.work.pk }}{% endif %}</td>
+              <td>{{ alloc.cost_centre|default:"—" }}</td>
+              <td class="text-end">${{ alloc.amount|floatformat:0 }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% endif %}
+
+      <!-- Level 4: Payments -->
+      {% if srow.payments %}
+      <div class="px-4 py-1 border-top">
+        <small class="text-muted fw-semibold">Payments</small>
+        <table class="table table-sm table-borderless mb-1">
+          <thead>
+            <tr class="text-muted small">
+              <th>Type</th><th>Status</th><th>Release Date</th><th class="text-end">Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for pmt in srow.payments %}
+            <tr class="small">
+              <td>{{ pmt.get_payment_type_display }}</td>
+              <td>
+                <span class="badge {% if pmt.status == 'RELEASED' or pmt.status == 'RECONCILED' %}bg-success{% elif pmt.status == 'APPROVED' %}bg-primary{% else %}bg-secondary{% endif %} small">
+                  {{ pmt.get_status_display }}
+                </span>
+              </td>
+              <td>{{ pmt.release_date|default:"—" }}</td>
+              <td class="text-end">${{ pmt.amount|floatformat:0 }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% endif %}
+
+      {% endfor %}
+    </div>
+  </div>
+  {% endfor %}
+
+  {% else %}
+  <div class="alert alert-info">
+    No funding agreements found for <strong>{{ selected_council.name }}</strong>.
+  </div>
+  {% endif %}
+
+  {% else %}
+  <div class="alert alert-light border">
+    Select a council above to view its full funding chain.
+  </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/src/apps/ui/urls.py
+++ b/src/apps/ui/urls.py
@@ -8,6 +8,8 @@ urlpatterns = [
     path('dashboard/', views.dashboard_views.dashboard_view, name='dashboard'),
     path('cashflow/', views.dashboard_views.cashflow_view, name='cashflow'),
     path('aggregate/', views.dashboard_views.aggregate_outputs_view, name='aggregate_outputs'),
+    path('dashboard/projects/', views.dashboard_views.projects_board_view, name='projects_board'),
+    path('dashboard/traceability/', views.dashboard_views.traceability_view, name='traceability'),
 
     # Maintenance views
     # path('maintenance/', views.maintenance_views.maintenance_list, name='maintenance_list'),

--- a/src/apps/ui/views/dashboard_views.py
+++ b/src/apps/ui/views/dashboard_views.py
@@ -1,125 +1,60 @@
-from django.shortcuts import render
-from django.db.models import Count, Sum, Q
-from django.contrib.auth.decorators import login_required
-from apps.core.models import Project
-from apps.core.models import Program
-from apps.core.models import Council
-from apps.core.models import FundingSchedule
-from apps.core.models import MonthlyTracker, QuarterlyReport, StageReport
+﻿import json
+from collections import defaultdict
 from datetime import date
 
+from django.contrib.auth.decorators import login_required
+from django.db.models import Count, Sum
+from django.shortcuts import render
 
-def get_user_permissions(request):
-    """Determine user role and permissions"""
-    if not request.user.is_authenticated:
-        return {
-            'is_fnc_user': False,
-            'is_council_user': False,
-            'can_edit_projects': False,
-            'can_approve_reports': False,
-            'user_group': None,
-            'council': None,
-        }
-    
-    user = request.user
-    is_fnc_user = False
-    is_council_user = False
-    can_edit_projects = False
-    can_approve_reports = False
-    user_group = None
-    council = None
-    
-    # Check if user is staff (FNC)
-    if user.is_staff:
-        is_fnc_user = True
-        can_edit_projects = True
-        can_approve_reports = True
-        user_group = 'FNC Manager'
-    
-    # Check group permissions
-    if hasattr(user, 'groups'):
-        for group in user.groups.all():
-            if 'FNC' in group.name:
-                is_fnc_user = True
-                can_edit_projects = True
-                can_approve_reports = True
-                user_group = group.name
-            elif 'Council' in group.name:
-                is_council_user = True
-                if 'Manager' in group.name:
-                    can_approve_reports = True
-                    user_group = group.name
-                else:
-                    user_group = group.name
-    
-    # Get council from profile
-    if hasattr(user, 'profile') and user.profile.council:
-        council = user.profile.council
-    
-    return {
-        'is_fnc_user': is_fnc_user,
-        'is_council_user': is_council_user,
-        'can_edit_projects': can_edit_projects,
-        'can_approve_reports': can_approve_reports,
-        'user_group': user_group,
-        'council': council,
-    }
+from apps.core.models import (
+    Council, FundingAgreement, FundingSchedule, Payment,
+    Program, Project, WorkFunding,
+)
 
+
+def _user_council(request):
+    """Return the council for council-scoped users, or None."""
+    try:
+        return request.user.profile.council
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Existing: main dashboard
+# ---------------------------------------------------------------------------
 
 @login_required
 def dashboard_view(request):
-    # Get user permissions
-    perms = get_user_permissions(request)
-    council = perms['council']
-    
-    # Get filter parameters
+    council = _user_council(request)
     council_id = request.GET.get('council')
     program_id = request.GET.get('program')
     status_filter = request.GET.get('status')
-    
-    # Base queryset - filter by council for council users
+
     projects = Project.objects.select_related('council', 'program').prefetch_related('funding_schedules')
-    
-    if perms['is_council_user'] and council:
+
+    if council:
         projects = projects.filter(council=council)
     elif council_id:
         projects = projects.filter(council_id=council_id)
-    
-    # Apply filters
+
     if program_id:
         projects = projects.filter(program_id=program_id)
     if status_filter:
         projects = projects.filter(status_flag=status_filter)
-    
-    # Calculate metrics
+
     total_projects = projects.count()
-    
-    # Status flags
     late_projects = projects.filter(status_flag=Project.StatusFlag.LATE).count()
     overdue_projects = projects.filter(status_flag=Project.StatusFlag.OVERDUE).count()
     on_track_projects = projects.filter(status_flag=Project.StatusFlag.ON_TRACK).count()
-    
-    # Budget metrics (total funding across all funding schedules)
-    total_budget = FundingSchedule.objects.filter(
-        project__in=projects
-    ).aggregate(total=Sum('total_funding'))['total'] or 0
-    
-    # Active projects (not completed)
-    active_projects = projects.exclude(
-        state__in=[Project.State.COMPLETED, 'CANCELLED']
-    ).count()
-    
-    # Get overdue reports
-    today = date.today()
-    # Monthly trackers overdue (14 days since month end)
-    # Quarterly reports overdue
-    # Stage reports that are due
-    
-    # Projects by state
+    total_budget = (
+        FundingSchedule.objects.filter(project__in=projects)
+        .aggregate(total=Sum('total_funding'))['total'] or 0
+    )
+    active_projects = projects.exclude(state__in=[Project.State.COMPLETED, 'CANCELLED']).count()
     projects_by_state = projects.values('state').annotate(count=Count('id'))
-    
-    # Context for template
-    context = {
+
+    return render(request, 'dashboard/dashboard.html', {
         'projects': projects,
         'total_projects': total_projects,
         'active_projects': active_projects,
@@ -128,104 +63,279 @@ def dashboard_view(request):
         'on_track_projects': on_track_projects,
         'total_budget': total_budget,
         'projects_by_state': projects_by_state,
-        'councils': Council.objects.all(),
-        'programs': Program.objects.all(),
+        'councils': Council.objects.all().order_by('name'),
+        'programs': Program.objects.all().order_by('name'),
         'selected_council': council_id,
         'selected_program': program_id,
         'selected_status': status_filter,
-        # RBAC
-        'is_fnc_user': perms['is_fnc_user'],
-        'is_council_user': perms['is_council_user'],
-        'can_edit_projects': perms['can_edit_projects'],
-        'can_approve_reports': perms['can_approve_reports'],
-        'user_group': perms['user_group'],
-    }
-    return render(request, 'dashboard/dashboard.html', context)
+    })
 
 
-def cashflow_view(request):
-    """Cashflow dashboard - forecast vs actual by FY"""
-    from apps.core.models import Payment
-    
-    # Get active projects with funding schedules
-    projects = Project.objects.exclude(
-        state=Project.State.COMPLETED
-    ).select_related('council', 'program').prefetch_related('funding_schedules', 'payments')
-    
-    # Calculate forecast (based on funding schedules)
-    total_forecast = FundingSchedule.objects.filter(
-        project__in=projects
-    ).aggregate(total=Sum('total_funding'))['total'] or 0
-    
-    # Calculate actual (released payments)
-    actual_payments = Payment.objects.filter(
-        project__in=projects,
-        status=Payment.Status.RELEASED
-    ).aggregate(total=Sum('amount'))['total'] or 0
-    
-    # Remaining
-    remaining = total_forecast - actual_payments
-    
-    # By program
-    by_program = []
-    for program in Program.objects.all():
-        program_projects = projects.filter(program=program)
-        forecast = FundingSchedule.objects.filter(project__in=program_projects).aggregate(
-            total=Sum('total_funding')
-        )['total'] or 0
-        actual = Payment.objects.filter(
-            project__in=program_projects,
-            status=Payment.Status.RELEASED
-        ).aggregate(total=Sum('amount'))['total'] or 0
-        drawdown_percent = (actual / forecast * 100) if forecast > 0 else 0
-        by_program.append({
-            'program': program,
-            'forecast': forecast,
-            'actual': actual,
-            'remaining': forecast - actual,
-            'drawdown_percent': drawdown_percent
-        })
-    
-    context = {
-        'projects': projects,
-        'total_forecast': total_forecast,
-        'actual_payments': actual_payments,
-        'remaining': remaining,
-        'by_program': by_program,
-    }
-    return render(request, 'dashboard/cashflow.html', context)
+# ---------------------------------------------------------------------------
+# Existing: aggregate outputs
+# ---------------------------------------------------------------------------
 
-
+@login_required
 def aggregate_outputs_view(request):
-    """Aggregate outputs by LGA, Program, Dwelling Type"""
-    from apps.core.models import Work, WorkType
-    
-    # By Council (LGA)
-    by_council = Project.objects.exclude(
-        state=Project.State.COMPLETED
-    ).values('council__name').annotate(
-        project_count=Count('id'),
-        total_budget=Sum('funding_schedules__total_funding')
+    from apps.core.models import Work
+
+    by_council = (
+        Project.objects.exclude(state=Project.State.COMPLETED)
+        .values('council__name')
+        .annotate(project_count=Count('id'), total_budget=Sum('funding_schedules__total_funding'))
     )
-    
-    # By Program
-    by_program = Project.objects.exclude(
-        state=Project.State.COMPLETED
-    ).values('program__name').annotate(
-        project_count=Count('id'),
-        total_budget=Sum('funding_schedules__total_funding')
+    by_program = (
+        Project.objects.exclude(state=Project.State.COMPLETED)
+        .values('program__name')
+        .annotate(project_count=Count('id'), total_budget=Sum('funding_schedules__total_funding'))
     )
-    
-    # By Work Type
-    by_work_type = Work.objects.filter(
-        project__state__in=[Project.State.COMMENCED, Project.State.UNDER_CONSTRUCTION]
-    ).values('work_type__name').annotate(
-        total_quantity=Sum('quantity')
+    by_work_type = (
+        Work.objects.filter(project__state__in=[Project.State.COMMENCED, Project.State.UNDER_CONSTRUCTION])
+        .values('work_type__name')
+        .annotate(total_quantity=Sum('quantity'))
     )
-    
-    context = {
+
+    return render(request, 'dashboard/aggregate.html', {
         'by_council': by_council,
         'by_program': by_program,
         'by_work_type': by_work_type,
-    }
-    return render(request, 'dashboard/aggregate.html', context)
+    })
+
+
+# ---------------------------------------------------------------------------
+# Issue #27 — Cashflow forecast (/dashboard/cashflow/)
+# ---------------------------------------------------------------------------
+
+@login_required
+def cashflow_view(request):
+    """Planned vs actual payment releases by month, with per-payment breakdown table."""
+    program_id = request.GET.get('program')
+    council_id = request.GET.get('council')
+
+    payments_qs = (
+        Payment.objects
+        .filter(status__in=[Payment.Status.APPROVED, Payment.Status.RELEASED])
+        .select_related('project', 'project__council', 'project__program', 'funding_schedule')
+        .order_by('release_date', 'project__name')
+    )
+    if program_id:
+        payments_qs = payments_qs.filter(project__program_id=program_id)
+    if council_id:
+        payments_qs = payments_qs.filter(project__council_id=council_id)
+
+    # Monthly buckets: planned = APPROVED, actual = RELEASED/RECONCILED
+    planned_by_month: dict = defaultdict(int)
+    actual_by_month: dict = defaultdict(int)
+
+    for p in payments_qs:
+        if not p.release_date:
+            continue
+        key = p.release_date.strftime('%Y-%m')
+        if p.status == Payment.Status.APPROVED:
+            planned_by_month[key] += int(p.amount or 0)
+        else:
+            actual_by_month[key] += int(p.amount or 0)
+
+    all_months = sorted(set(list(planned_by_month.keys()) + list(actual_by_month.keys())))
+
+    # Summary totals
+    total_forecast = (
+        payments_qs.aggregate(total=Sum('amount'))['total'] or 0
+    )
+    total_released = (
+        payments_qs.filter(status__in=[Payment.Status.RELEASED])
+        .aggregate(total=Sum('amount'))['total'] or 0
+    )
+    remaining = total_forecast - total_released
+
+    # By program summary
+    by_program = []
+    for prog in Program.objects.order_by('name'):
+        qs = payments_qs.filter(project__program=prog)
+        forecast = qs.aggregate(t=Sum('amount'))['t'] or 0
+        actual = qs.filter(
+            status__in=[Payment.Status.RELEASED]
+        ).aggregate(t=Sum('amount'))['t'] or 0
+        drawdown_pct = round(actual / forecast * 100, 1) if forecast else 0
+        by_program.append({
+            'program': prog,
+            'forecast': forecast,
+            'actual': actual,
+            'remaining': forecast - actual,
+            'drawdown_percent': drawdown_pct,
+        })
+
+    return render(request, 'dashboard/cashflow.html', {
+        'payments': payments_qs,
+        'chart_labels': json.dumps(all_months),
+        'chart_planned': json.dumps([planned_by_month.get(m, 0) for m in all_months]),
+        'chart_actual': json.dumps([actual_by_month.get(m, 0) for m in all_months]),
+        'total_forecast': total_forecast,
+        'total_released': total_released,
+        'remaining': remaining,
+        'by_program': by_program,
+        'councils': Council.objects.all().order_by('name'),
+        'programs': Program.objects.all().order_by('name'),
+        'selected_program': program_id,
+        'selected_council': council_id,
+    })
+
+
+# ---------------------------------------------------------------------------
+# Issue #26 — Project status board (/dashboard/projects/)
+# ---------------------------------------------------------------------------
+
+@login_required
+def projects_board_view(request):
+    """Kanban-style project status board grouped by lifecycle stage."""
+    program_id = request.GET.get('program')
+    council_id = request.GET.get('council')
+    financial_year = request.GET.get('financial_year')
+
+    projects = (
+        Project.objects
+        .select_related('council', 'program')
+        .prefetch_related('funding_schedules')
+        .order_by('name')
+    )
+    if program_id:
+        projects = projects.filter(program_id=program_id)
+    if council_id:
+        projects = projects.filter(council_id=council_id)
+    if financial_year:
+        projects = projects.filter(financial_year=financial_year)
+
+    today = date.today()
+
+    def _card(project):
+        total_funding = (
+            project.funding_schedules.aggregate(t=Sum('total_funding'))['t'] or 0
+        )
+        target = project.completion_date or project.stage2_sunset_date
+        days_left = (target - today).days if target else None
+        return {
+            'project': project,
+            'total_funding': total_funding,
+            'days_left': days_left,
+            'overdue': days_left is not None and days_left < 0,
+        }
+
+    column_order = [
+        Project.State.PROSPECTIVE,
+        Project.State.PROGRAMMED,
+        Project.State.FUNDED,
+        Project.State.COMMENCED,
+        Project.State.UNDER_CONSTRUCTION,
+        Project.State.COMPLETED,
+    ]
+    state_labels = dict(Project.State.choices)
+
+    columns = []
+    for state in column_order:
+        state_projects = [_card(p) for p in projects if p.state == state]
+        columns.append({
+            'state': state,
+            'label': state_labels.get(state, state),
+            'projects': state_projects,
+            'count': len(state_projects),
+        })
+
+    financial_years = (
+        Project.objects.exclude(financial_year='')
+        .values_list('financial_year', flat=True)
+        .distinct()
+        .order_by('financial_year')
+    )
+
+    return render(request, 'dashboard/projects_board.html', {
+        'columns': columns,
+        'councils': Council.objects.all().order_by('name'),
+        'programs': Program.objects.all().order_by('name'),
+        'financial_years': financial_years,
+        'selected_program': program_id,
+        'selected_council': council_id,
+        'selected_year': financial_year,
+        'total_projects': sum(c['count'] for c in columns),
+    })
+
+
+# ---------------------------------------------------------------------------
+# Issue #25 — Financial traceability (/dashboard/traceability/)
+# ---------------------------------------------------------------------------
+
+@login_required
+def traceability_view(request):
+    """'Follow the money' drill-down: Council → Agreement → Schedule → Allocations → Payments."""
+    council_id = request.GET.get('council')
+    selected_council = None
+    chain = []
+
+    if council_id:
+        selected_council = Council.objects.filter(pk=council_id).first()
+
+    if selected_council:
+        agreements = (
+            FundingAgreement.objects.filter(council=selected_council)
+            .order_by('-execution_date')
+        )
+        for agreement in agreements:
+            schedules = (
+                FundingSchedule.objects.filter(funding_agreement=agreement)
+                .select_related('project', 'payment_rule')
+                .order_by('schedule_number')
+            )
+            agreement_total = 0
+            agreement_paid = 0
+            schedule_rows = []
+
+            for schedule in schedules:
+                payments = (
+                    Payment.objects.filter(funding_schedule=schedule)
+                    .select_related('project')
+                    .order_by('release_date')
+                )
+                allocations = (
+                    WorkFunding.objects.filter(funding_schedule=schedule)
+                    .select_related('project', 'work')
+                )
+                paid = (
+                    payments.filter(status__in=[Payment.Status.RELEASED])
+                    .aggregate(t=Sum('amount'))['t'] or 0
+                )
+                pct = round(paid / schedule.total_funding * 100, 1) if schedule.total_funding else 0
+                remaining = schedule.total_funding - paid
+                agreement_total += schedule.total_funding
+                agreement_paid += paid
+
+                schedule_rows.append({
+                    'schedule': schedule,
+                    'paid': paid,
+                    'remaining': remaining,
+                    'pct_expended': pct,
+                    'allocations': list(allocations),
+                    'payments': list(payments),
+                })
+
+            agreement_pct = round(agreement_paid / agreement_total * 100, 1) if agreement_total else 0
+            chain.append({
+                'agreement': agreement,
+                'total': agreement_total,
+                'paid': agreement_paid,
+                'remaining': agreement_total - agreement_paid,
+                'pct_expended': agreement_pct,
+                'schedules': schedule_rows,
+            })
+
+    grand_total = sum(a['total'] for a in chain)
+    grand_paid = sum(a['paid'] for a in chain)
+    grand_pct = round(grand_paid / grand_total * 100, 1) if grand_total else 0
+
+    return render(request, 'dashboard/traceability.html', {
+        'councils': Council.objects.all().order_by('name'),
+        'selected_council': selected_council,
+        'chain': chain,
+        'grand_total': grand_total,
+        'grand_paid': grand_paid,
+        'grand_remaining': grand_total - grand_paid,
+        'grand_pct': grand_pct,
+    })

--- a/tests/test_issue_25_26_27_dashboards.py
+++ b/tests/test_issue_25_26_27_dashboards.py
@@ -1,0 +1,363 @@
+﻿"""
+Tests for dashboard issues:
+  #25 — Financial traceability view (/dashboard/traceability/)
+  #26 — Project status board (/dashboard/projects/)
+  #27 — Cashflow forecast (/dashboard/cashflow/)
+"""
+import json
+import pytest
+from datetime import date
+from decimal import Decimal
+from django.test import Client
+from django.contrib.auth.models import User
+
+from apps.core.models import (
+    Council, Program, Project, FundingSchedule, FundingAgreement,
+    Payment, WorkFunding, Profile,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def council():
+    return Council.objects.create(name='Dash Council', region='QLD')
+
+
+@pytest.fixture
+def program(council):
+    return Program.objects.create(
+        name='Dash Program',
+        funding_source=Program.FundingSource.STATE,
+        budget=Decimal('5000000'),
+    )
+
+
+@pytest.fixture
+def project(council, program):
+    return Project.objects.create(
+        name='Dash Project', council=council, program=program,
+        state=Project.State.FUNDED, financial_year='2025-2026',
+    )
+
+
+@pytest.fixture
+def funding_schedule(project):
+    return FundingSchedule.objects.create(
+        project=project,
+        amount=Decimal('300000'),
+        contingency=Decimal('0'),
+        payment_split=FundingSchedule.PaymentSplit.STANDARD,
+        status=FundingSchedule.Status.ACTIVE,
+    )
+
+
+@pytest.fixture
+def funding_agreement(council, funding_schedule):
+    fa = FundingAgreement.objects.create(
+        council=council,
+        name='Dash Agreement',
+        status=FundingAgreement.Status.ACTIVE,
+        execution_date=date(2025, 1, 15),
+    )
+    funding_schedule.funding_agreement = fa
+    funding_schedule.save()
+    return fa
+
+
+@pytest.fixture
+def released_payment(project, funding_schedule):
+    return Payment.objects.create(
+        project=project,
+        funding_schedule=funding_schedule,
+        payment_type=Payment.PaymentType.FIRST,
+        calculation_type=Payment.CalculationType.PERCENTAGE,
+        amount=Decimal('180000'),
+        status=Payment.Status.RELEASED,
+        release_date=date(2025, 3, 10),
+    )
+
+
+@pytest.fixture
+def approved_payment(project, funding_schedule):
+    return Payment.objects.create(
+        project=project,
+        funding_schedule=funding_schedule,
+        payment_type=Payment.PaymentType.SECOND,
+        calculation_type=Payment.CalculationType.PERCENTAGE,
+        amount=Decimal('120000'),
+        status=Payment.Status.APPROVED,
+        release_date=date(2025, 9, 1),
+    )
+
+
+@pytest.fixture
+def auth_client(council):
+    client = Client()
+    user = User.objects.create_user(username='dash_officer', password='pass')
+    Profile.objects.create(user=user, council=council, officer_role=Profile.OfficerRole.OFFICER)
+    client.force_login(user)
+    return client, user
+
+
+# ===========================================================================
+# Issue #27 — Cashflow forecast
+# ===========================================================================
+
+@pytest.mark.django_db
+class TestCashflowView:
+    def test_get_returns_200(self, auth_client):
+        client, _ = auth_client
+        response = client.get('/cashflow/')
+        assert response.status_code == 200
+
+    def test_requires_login(self):
+        response = Client().get('/cashflow/')
+        assert response.status_code == 302
+        assert '/accounts/login/' in response['Location']
+
+    def test_shows_released_payment_amount(self, auth_client, released_payment):
+        client, _ = auth_client
+        response = client.get('/cashflow/')
+        assert response.status_code == 200
+        assert b'180' in response.content
+
+    def test_chart_data_in_context(self, auth_client, released_payment, approved_payment):
+        client, _ = auth_client
+        response = client.get('/cashflow/')
+        ctx = response.context
+        labels = json.loads(ctx['chart_labels'])
+        planned = json.loads(ctx['chart_planned'])
+        actual = json.loads(ctx['chart_actual'])
+        assert isinstance(labels, list)
+        assert isinstance(planned, list)
+        assert isinstance(actual, list)
+        assert len(labels) == len(planned) == len(actual)
+
+    def test_filter_by_program(self, auth_client, released_payment, program):
+        client, _ = auth_client
+        response = client.get(f'/cashflow/?program={program.pk}')
+        assert response.status_code == 200
+        assert b'180' in response.content
+
+    def test_filter_by_council(self, auth_client, released_payment, council):
+        client, _ = auth_client
+        response = client.get(f'/cashflow/?council={council.pk}')
+        assert response.status_code == 200
+
+    def test_filter_excludes_other_council(self, auth_client, released_payment):
+        client, _ = auth_client
+        other = Council.objects.create(name='Other Council CF', region='NSW')
+        response = client.get(f'/cashflow/?council={other.pk}')
+        assert response.status_code == 200
+        # released_payment is $180k for Dash Council — should not appear
+        ctx = response.context
+        assert ctx['total_forecast'] == 0 or ctx['total_released'] == 0
+
+    def test_total_released_excludes_approved(self, auth_client, released_payment, approved_payment):
+        client, _ = auth_client
+        response = client.get('/cashflow/')
+        ctx = response.context
+        assert ctx['total_released'] == Decimal('180000')
+        assert ctx['total_forecast'] == Decimal('300000')
+
+    def test_approved_payment_in_planned_bucket(self, auth_client, approved_payment):
+        client, _ = auth_client
+        response = client.get('/cashflow/')
+        ctx = response.context
+        planned = json.loads(ctx['chart_planned'])
+        assert sum(planned) == 120000  # only the APPROVED payment
+
+    def test_by_program_includes_drawdown(self, auth_client, released_payment, program):
+        client, _ = auth_client
+        response = client.get('/cashflow/')
+        ctx = response.context
+        prog_row = next((r for r in ctx['by_program'] if r['program'] == program), None)
+        assert prog_row is not None
+        assert prog_row['drawdown_percent'] > 0
+
+
+# ===========================================================================
+# Issue #26 — Project status board
+# ===========================================================================
+
+@pytest.mark.django_db
+class TestProjectsBoardView:
+    def test_get_returns_200(self, auth_client):
+        client, _ = auth_client
+        response = client.get('/dashboard/projects/')
+        assert response.status_code == 200
+
+    def test_requires_login(self):
+        response = Client().get('/dashboard/projects/')
+        assert response.status_code == 302
+        assert '/accounts/login/' in response['Location']
+
+    def test_project_appears_in_correct_column(self, auth_client, project):
+        client, _ = auth_client
+        response = client.get('/dashboard/projects/')
+        ctx = response.context
+        funded_col = next(c for c in ctx['columns'] if c['state'] == Project.State.FUNDED)
+        names = [card['project'].name for card in funded_col['projects']]
+        assert project.name in names
+
+    def test_all_six_columns_present(self, auth_client):
+        client, _ = auth_client
+        response = client.get('/dashboard/projects/')
+        ctx = response.context
+        states = [c['state'] for c in ctx['columns']]
+        expected = [
+            Project.State.PROSPECTIVE, Project.State.PROGRAMMED, Project.State.FUNDED,
+            Project.State.COMMENCED, Project.State.UNDER_CONSTRUCTION, Project.State.COMPLETED,
+        ]
+        for s in expected:
+            assert s in states
+        assert len(states) == 6
+
+    def test_filter_by_program(self, auth_client, project, program):
+        client, _ = auth_client
+        response = client.get(f'/dashboard/projects/?program={program.pk}')
+        assert response.status_code == 200
+        ctx = response.context
+        assert ctx['total_projects'] >= 1
+
+    def test_filter_by_council_excludes_others(self, auth_client, project):
+        client, _ = auth_client
+        other = Council.objects.create(name='Other Board Council', region='NSW')
+        response = client.get(f'/dashboard/projects/?council={other.pk}')
+        assert response.status_code == 200
+        ctx = response.context
+        assert ctx['total_projects'] == 0
+
+    def test_filter_by_financial_year(self, auth_client, project):
+        client, _ = auth_client
+        response = client.get('/dashboard/projects/?financial_year=2025-2026')
+        ctx = response.context
+        assert ctx['total_projects'] >= 1
+
+    def test_card_has_total_funding(self, auth_client, project, funding_schedule):
+        client, _ = auth_client
+        response = client.get('/dashboard/projects/')
+        ctx = response.context
+        funded_col = next(c for c in ctx['columns'] if c['state'] == Project.State.FUNDED)
+        card = next((c for c in funded_col['projects'] if c['project'] == project), None)
+        assert card is not None
+        assert card['total_funding'] == Decimal('300000')
+
+    def test_overdue_card_flagged(self, auth_client, council, program):
+        client, _ = auth_client
+        Project.objects.create(
+            name='Overdue Board Project', council=council, program=program,
+            state=Project.State.COMMENCED,
+            financial_year='2024-2025',
+            completion_date=date(2020, 1, 1),
+        )
+        response = client.get('/dashboard/projects/')
+        ctx = response.context
+        commenced_col = next(c for c in ctx['columns'] if c['state'] == Project.State.COMMENCED)
+        overdue_cards = [c for c in commenced_col['projects'] if c['overdue']]
+        assert len(overdue_cards) >= 1
+
+    def test_project_with_no_completion_date_not_overdue(self, auth_client, project):
+        client, _ = auth_client
+        response = client.get('/dashboard/projects/')
+        ctx = response.context
+        funded_col = next(c for c in ctx['columns'] if c['state'] == Project.State.FUNDED)
+        card = next((c for c in funded_col['projects'] if c['project'] == project), None)
+        assert card is not None
+        assert card['days_left'] is None
+        assert card['overdue'] is False
+
+
+# ===========================================================================
+# Issue #25 — Financial traceability
+# ===========================================================================
+
+@pytest.mark.django_db
+class TestTraceabilityView:
+    def test_get_no_council_returns_200(self, auth_client):
+        client, _ = auth_client
+        response = client.get('/dashboard/traceability/')
+        assert response.status_code == 200
+
+    def test_requires_login(self):
+        response = Client().get('/dashboard/traceability/')
+        assert response.status_code == 302
+        assert '/accounts/login/' in response['Location']
+
+    def test_council_picker_shown_without_param(self, auth_client, council):
+        client, _ = auth_client
+        response = client.get('/dashboard/traceability/')
+        assert council.name.encode() in response.content
+
+    def test_agreement_shown_for_council(self, auth_client, council, funding_agreement):
+        client, _ = auth_client
+        response = client.get(f'/dashboard/traceability/?council={council.pk}')
+        assert response.status_code == 200
+        assert b'Dash Agreement' in response.content
+
+    def test_schedule_shown_under_agreement(self, auth_client, council, funding_agreement, funding_schedule):
+        client, _ = auth_client
+        response = client.get(f'/dashboard/traceability/?council={council.pk}')
+        ctx = response.context
+        assert len(ctx['chain']) == 1
+        assert len(ctx['chain'][0]['schedules']) == 1
+
+    def test_payments_shown_in_chain(self, auth_client, council, funding_agreement, released_payment):
+        client, _ = auth_client
+        response = client.get(f'/dashboard/traceability/?council={council.pk}')
+        ctx = response.context
+        srow = ctx['chain'][0]['schedules'][0]
+        assert len(srow['payments']) == 1
+        assert srow['payments'][0].amount == Decimal('180000')
+
+    def test_pct_expended_calculated(self, auth_client, council, funding_agreement, released_payment):
+        client, _ = auth_client
+        response = client.get(f'/dashboard/traceability/?council={council.pk}')
+        ctx = response.context
+        srow = ctx['chain'][0]['schedules'][0]
+        # 180000 / 300000 = 60%
+        assert srow['pct_expended'] == 60.0
+
+    def test_grand_totals_aggregated(self, auth_client, council, funding_agreement, released_payment):
+        client, _ = auth_client
+        response = client.get(f'/dashboard/traceability/?council={council.pk}')
+        ctx = response.context
+        assert ctx['grand_total'] == Decimal('300000')
+        assert ctx['grand_paid'] == Decimal('180000')
+        assert ctx['grand_remaining'] == Decimal('120000')
+        assert ctx['grand_pct'] == 60.0
+
+    def test_no_agreements_shows_empty_state(self, auth_client):
+        client, _ = auth_client
+        empty = Council.objects.create(name='Empty Council', region='VIC')
+        response = client.get(f'/dashboard/traceability/?council={empty.pk}')
+        assert response.status_code == 200
+        assert b'No funding agreements' in response.content
+
+    def test_allocations_shown_in_chain(self, auth_client, council, funding_agreement, funding_schedule, project):
+        client, _ = auth_client
+        WorkFunding.objects.create(
+            funding_schedule=funding_schedule,
+            project=project,
+            cost_centre='316001',
+            amount=Decimal('300000'),
+        )
+        response = client.get(f'/dashboard/traceability/?council={council.pk}')
+        ctx = response.context
+        srow = ctx['chain'][0]['schedules'][0]
+        assert len(srow['allocations']) == 1
+        assert srow['allocations'][0].cost_centre == '316001'
+
+    def test_running_totals_at_agreement_level(self, auth_client, council, funding_agreement,
+                                                released_payment, approved_payment):
+        client, _ = auth_client
+        response = client.get(f'/dashboard/traceability/?council={council.pk}')
+        ctx = response.context
+        agreement_row = ctx['chain'][0]
+        assert agreement_row['total'] == Decimal('300000')
+        # only RELEASED counts as paid
+        assert agreement_row['paid'] == Decimal('180000')
+        assert agreement_row['pct_expended'] == 60.0


### PR DESCRIPTION
## Summary

**Issue #25 — Financial traceability** (`/dashboard/traceability/`)
- Council picker entry point
- Drill-down: FundingAgreements → FundingSchedules → Allocations → Payments
- Running totals and % expended with progress bars at every level

**Issue #26 — Project status board** (`/dashboard/projects/`)
- Kanban layout across all 6 lifecycle states (PROSPECTIVE → COMPLETED)
- Cards show: project name, council, program, total funding, days to completion
- Overdue indicator (red badge) for projects past completion/sunset date
- Filters: program, council, financial year

**Issue #27 — Cashflow forecast** (`/dashboard/cashflow/`)
- Replaces the existing basic cashflow view
- Planned (APPROVED) vs actual (RELEASED) monthly payment profile
- Chart.js grouped bar chart (CDN, no install required)
- Filters: program, council
- Program summary table with drawdown % and progress bar
- Full payment breakdown table with project and schedule links

## Test plan

- [ ] `pytest tests/test_issue_25_26_27_dashboards.py` — 31 passed
- [ ] Full suite: 565 passed, 17 skipped, 3 xfailed, 0 failures
- [ ] All three views require login (302 redirect without session)
- [ ] Traceability pct_expended = 60.0% for 180k paid on 300k schedule
- [ ] Projects board places FUNDED project in FUNDED column, not others
- [ ] Cashflow total_released excludes APPROVED payments

🤖 Generated with [Claude Code](https://claude.com/claude-code)