### PR TITLE
Funding Approvals: rename BFA, maintenance-managed delegate positions…

### DIFF
--- a/docs/RICD_domain_model.md
+++ b/docs/RICD_domain_model.md
@@ -287,7 +287,7 @@ The RICD system manages the full lifecycle of government-funded housing and infr
 | `id` | PK |
 | `project_id` | FK → Project |
 | `funding_amount` | Decimal |
-| `delegate_level` | enum: `MANAGER`, `DIRECTOR`, `GM` |
+| `delegate_position_id` | FK → DelegatePosition (maintenance-managed; title + max approval amount) |
 | `approval_status` | enum: `PENDING`, `APPROVED`, `REJECTED` |
 | `approved_by_id` | FK → User |
 | `approved_at` | timestamp |

--- a/src/apps/api/serializers/funding.py
+++ b/src/apps/api/serializers/funding.py
@@ -75,7 +75,7 @@ class BriefFinancialApprovalSerializer(serializers.ModelSerializer):
         fields = [
             'id', 'mincor_reference', 'document_uri',
             'funding_amount', 'contingency_amount', 'total_amount', 'project_count',
-            'delegate_level', 'status', 'approved_by', 'approved_at',
+            'delegate_position', 'status', 'approved_by', 'approved_at',
         ]
         read_only_fields = ['id', 'approved_at',
                             'funding_amount', 'contingency_amount', 'total_amount', 'project_count']

--- a/src/apps/core/admin.py
+++ b/src/apps/core/admin.py
@@ -118,8 +118,8 @@ class BriefFinancialApprovalItemInline(admin.TabularInline):
 
 @admin.register(BriefFinancialApproval)
 class BriefFinancialApprovalAdmin(admin.ModelAdmin):
-    list_display = ('mincor_reference', 'project_count_col', 'total_amount_col', 'status', 'delegate_level')
-    list_filter = ('status', 'delegate_level')
+    list_display = ('mincor_reference', 'project_count_col', 'total_amount_col', 'status', 'delegate_position')
+    list_filter = ('status', 'delegate_position')
     search_fields = ('mincor_reference', 'document_uri')
     inlines = [BriefFinancialApprovalItemInline]
 

--- a/src/apps/core/migrations/0051_delegateposition.py
+++ b/src/apps/core/migrations/0051_delegateposition.py
@@ -1,0 +1,102 @@
+# DelegatePosition: maintenance-managed delegation positions replace the
+# hardcoded BriefFinancialApproval.DelegateLevel choices.
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+# Old hardcoded delegate_level value -> seeded position title.
+_LEVEL_TO_TITLE = {
+    'MGR': 'Manager',
+    'DIR': 'Director',
+    'GM': 'General Manager',
+}
+
+# Seed rows: (title, max_approval_amount, order). None amount == unlimited.
+# Amounts are sensible starting points — edit them in Maintenance.
+_SEED = [
+    ('Manager', 250000, 1),
+    ('Director', 1000000, 2),
+    ('General Manager', None, 3),
+]
+
+
+def seed_and_map(apps, schema_editor):
+    DelegatePosition = apps.get_model('core', 'DelegatePosition')
+    BriefFinancialApproval = apps.get_model('core', 'BriefFinancialApproval')
+
+    title_to_obj = {}
+    for title, amount, order in _SEED:
+        obj, _ = DelegatePosition.objects.get_or_create(
+            title=title, defaults={'max_approval_amount': amount, 'order': order},
+        )
+        title_to_obj[title] = obj
+
+    for bfa in BriefFinancialApproval.objects.all():
+        title = _LEVEL_TO_TITLE.get(bfa.delegate_level)
+        if title and title in title_to_obj:
+            bfa.delegate_position = title_to_obj[title]
+            bfa.save(update_fields=['delegate_position'])
+
+
+def unmap(apps, schema_editor):
+    # delegate_level is removed on forward, so there's nothing to restore.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0050_cashflowmethodrule"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="DelegatePosition",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True,
+                        serialize=False, verbose_name="ID",
+                    ),
+                ),
+                ("title", models.CharField(max_length=100, unique=True)),
+                (
+                    "max_approval_amount",
+                    models.DecimalField(
+                        blank=True, decimal_places=2, max_digits=14, null=True,
+                        help_text="Maximum amount this position may approve. Leave blank for unlimited.",
+                    ),
+                ),
+                ("notes", models.TextField(blank=True)),
+                ("is_active", models.BooleanField(default=True)),
+                (
+                    "order",
+                    models.PositiveIntegerField(
+                        default=0, help_text="Display order (low to high)."),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "verbose_name": "Delegate position",
+                "ordering": ["order", "title"],
+            },
+        ),
+        migrations.AddField(
+            model_name="brieffinancialapproval",
+            name="delegate_position",
+            field=models.ForeignKey(
+                blank=True, null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="approvals", to="core.delegateposition",
+                help_text="Delegation position approving this. Managed in Maintenance → Delegate Positions.",
+            ),
+        ),
+        migrations.RunPython(seed_and_map, unmap),
+        migrations.RemoveField(
+            model_name="brieffinancialapproval",
+            name="delegate_level",
+        ),
+    ]

--- a/src/apps/core/models/__init__.py
+++ b/src/apps/core/models/__init__.py
@@ -21,6 +21,7 @@ from .funding_models import (
     PaymentRule,
     PaymentRuleMilestone,
     FundingAgreement,
+    DelegatePosition,
     BriefFinancialApproval,
     BriefFinancialApprovalItem,
     PaymentAllocation,
@@ -97,7 +98,7 @@ __all__ = [
     # Land Infrastructure
     'LandTenure', 'DevelopmentApplication', 'LandPreCondition',
     # Funding & Payment
-    'PaymentRule', 'PaymentRuleMilestone', 'FundingAgreement', 'BriefFinancialApproval', 'BriefFinancialApprovalItem', 'PaymentAllocation',
+    'PaymentRule', 'PaymentRuleMilestone', 'FundingAgreement', 'DelegatePosition', 'BriefFinancialApproval', 'BriefFinancialApprovalItem', 'PaymentAllocation',
     'FundingNotice', 'ExpenseClaim', 'ExpenseClaimAttachment', 'Delegation',
     'FundingSchedule', 'ProjectStateLog', 'WorkFunding',
     'Approval', 'WorkflowAction', 'AuditLog', 'Payment',

--- a/src/apps/core/models/funding_models.py
+++ b/src/apps/core/models/funding_models.py
@@ -136,6 +136,35 @@ class FundingAgreement(models.Model):
 
 
 # ============================================================================
+# DelegatePosition - maintenance-managed financial delegation positions
+# ============================================================================
+
+class DelegatePosition(models.Model):
+    """A financial-delegation position (e.g. Manager, Director) and the maximum
+    amount it may approve. Maintained via the Maintenance portal — replaces the
+    old hardcoded BriefFinancialApproval.DelegateLevel choices."""
+    title = models.CharField(max_length=100, unique=True)
+    max_approval_amount = models.DecimalField(
+        max_digits=14, decimal_places=2, null=True, blank=True,
+        help_text="Maximum amount this position may approve. Leave blank for unlimited.",
+    )
+    notes = models.TextField(blank=True)
+    is_active = models.BooleanField(default=True)
+    order = models.PositiveIntegerField(default=0, help_text="Display order (low to high).")
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ['order', 'title']
+        verbose_name = 'Delegate position'
+
+    def __str__(self):
+        if self.max_approval_amount is not None:
+            return f"{self.title} — up to ${self.max_approval_amount:,.0f}"
+        return f"{self.title} — unlimited"
+
+
+# ============================================================================
 # BriefFinancialApproval - Pre-condition for funding creation
 # ============================================================================
 
@@ -148,11 +177,6 @@ class BriefFinancialApproval(models.Model):
         PENDING = 'PENDING', 'Pending'
         APPROVED = 'APPROVED', 'Approved'
         REJECTED = 'REJECTED', 'Rejected'
-
-    class DelegateLevel(models.TextChoices):
-        MANAGER = 'MGR', 'Manager'
-        DIRECTOR = 'DIR', 'Director'
-        GM = 'GM', 'General Manager'
 
     mincor_reference = models.CharField(
         max_length=50, blank=True, db_index=True,
@@ -167,7 +191,11 @@ class BriefFinancialApproval(models.Model):
         help_text="Link to the Human Rights Assessment that accompanies this brief "
                   "(required alongside the FAS for financial approval).",
     )
-    delegate_level = models.CharField(max_length=3, choices=DelegateLevel.choices, default=DelegateLevel.MANAGER)
+    delegate_position = models.ForeignKey(
+        'DelegatePosition', null=True, blank=True, on_delete=models.SET_NULL,
+        related_name='approvals',
+        help_text="Delegation position approving this. Managed in Maintenance → Delegate Positions.",
+    )
     status = models.CharField(max_length=10, choices=Status.choices, default=Status.PENDING, db_index=True)
     approved_by = models.ForeignKey(User, related_name='brief_approvals', null=True, blank=True, on_delete=models.SET_NULL)
     approved_at = models.DateTimeField(null=True, blank=True)

--- a/src/apps/ui/templates/brief_financial_approvals/detail.html
+++ b/src/apps/ui/templates/brief_financial_approvals/detail.html
@@ -1,21 +1,21 @@
 {% extends "base.html" %}
 {% load money %}
-{% block title %}BFA {{ bfa.mincor_reference|default:bfa.pk }} — RICD{% endblock %}
+{% block title %}Funding Approval {{ bfa.mincor_reference|default:bfa.pk }} — RICD{% endblock %}
 {% block breadcrumbs %}
   <span class="sep">/</span>
-  <a href="{% url 'ui:bfa_global_list' %}">Brief Financial Approvals</a>
+  <a href="{% url 'ui:bfa_global_list' %}">Funding Approvals</a>
   <span class="sep">/</span>
-  <span class="current">{{ bfa.mincor_reference|default:"BFA" }} #{{ bfa.pk }}</span>
+  <span class="current">{{ bfa.mincor_reference|default:"Funding Approval" }} #{{ bfa.pk }}</span>
 {% endblock %}
 {% block content %}
 <div class="pg-head">
   <div>
-    <h1>{{ bfa.mincor_reference|default:"BFA" }} #{{ bfa.pk }}</h1>
+    <h1>{{ bfa.mincor_reference|default:"Funding Approval" }} #{{ bfa.pk }}</h1>
     <div class="meta">
       {% for c in bfa.councils %}<a href="{% url 'ui:council_detail' c.pk %}">{{ c.name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}
       {% if bfa.councils %} &middot; {% endif %}
       {{ bfa.project_count }} project{{ bfa.project_count|pluralize }} &middot;
-      {{ bfa.get_delegate_level_display }} delegate
+      {{ bfa.delegate_position.title|default:"No" }} delegate
       {% if bfa.document_uri %} &middot; <a href="{{ bfa.document_uri }}" target="_blank" rel="noopener"><i class="bi bi-link-45deg"></i> Brief document</a>{% endif %}
     </div>
   </div>
@@ -90,7 +90,7 @@
         {% if not is_council %}<td class="text-end {% if item.remaining < 0 %}text-danger{% endif %}">{{ item.remaining|money }}</td>{% endif %}
       </tr>
     {% empty %}
-      <tr><td colspan="{% if is_council %}7{% else %}10{% endif %}" class="text-center text-muted">No project rows — edit this BFA to add one.</td></tr>
+      <tr><td colspan="{% if is_council %}7{% else %}10{% endif %}" class="text-center text-muted">No project rows — edit this funding approval to add one.</td></tr>
     {% endfor %}
       <tr class="table-light">
         <td class="fw-bold" colspan="5">Totals</td>
@@ -111,7 +111,7 @@
     <dt class="col-sm-3">MINCOR ref</dt><dd class="col-sm-9">{{ bfa.mincor_reference|default:"—" }}</dd>
     <dt class="col-sm-3">Brief document</dt><dd class="col-sm-9">{% if bfa.document_uri %}<a href="{{ bfa.document_uri }}" target="_blank" rel="noopener">{{ bfa.document_uri }}</a>{% else %}<span class="text-muted">—</span>{% endif %}</dd>
     <dt class="col-sm-3">Council(s)</dt><dd class="col-sm-9">{% for c in bfa.councils %}<a href="{% url 'ui:council_detail' c.pk %}">{{ c.name }}</a>{% if not forloop.last %}, {% endif %}{% empty %}<span class="text-muted">—</span>{% endfor %}</dd>
-    <dt class="col-sm-3">Delegate level</dt><dd class="col-sm-9">{{ bfa.get_delegate_level_display }}</dd>
+    <dt class="col-sm-3">Delegate position</dt><dd class="col-sm-9">{% if bfa.delegate_position %}{{ bfa.delegate_position.title }}{% if bfa.delegate_position.max_approval_amount %} <span class="text-muted">(up to {{ bfa.delegate_position.max_approval_amount|money }})</span>{% endif %}{% else %}<span class="text-muted">—</span>{% endif %}</dd>
     <dt class="col-sm-3">Comments</dt><dd class="col-sm-9" style="white-space:pre-wrap;">{{ bfa.comments|default:"—" }}</dd>
     <dt class="col-sm-3">Approved by</dt><dd class="col-sm-9">{% if bfa.approved_by %}{{ bfa.approved_by.get_full_name|default:bfa.approved_by.username }}{% else %}—{% endif %}</dd>
     <dt class="col-sm-3">Approved at</dt><dd class="col-sm-9">{{ bfa.approved_at|default:"—" }}</dd>

--- a/src/apps/ui/templates/brief_financial_approvals/form.html
+++ b/src/apps/ui/templates/brief_financial_approvals/form.html
@@ -3,7 +3,7 @@
 {% block title %}{{ title }} — RICD{% endblock %}
 {% block breadcrumbs %}
   <span class="sep">/</span>
-  <a href="{% url 'ui:bfa_global_list' %}">Brief Financial Approvals</a>
+  <a href="{% url 'ui:bfa_global_list' %}">Funding Approvals</a>
   <span class="sep">/</span>
   <span class="current">{{ title }}</span>
 {% endblock %}
@@ -11,7 +11,7 @@
 <div class="pg-head">
   <div>
     <h1>{{ title }}</h1>
-    <div class="meta">Header attributes (MINCOR reference, council, delegate level) plus per-project funding rows.</div>
+    <div class="meta">Header attributes (MINCOR reference, delegate position) plus per-project funding rows.</div>
   </div>
 </div>
 
@@ -44,7 +44,9 @@
       <strong>Program defaults to the project's program;</strong> change it only to capture
       co-funding from a different program (e.g. Commonwealth + Department). You can
       add multiple rows for the same project with different programs to split funding.
-      Contingency defaults to 10% if blank. Total = funding + contingency.
+      <strong>Pick a project and its funding amount auto-fills from the sum of its works</strong>
+      (estimated cost × quantity); contingency defaults to 10%. You can override either.
+      Total = funding + contingency.
     </p>
 
     {{ items_formset.management_form }}
@@ -96,4 +98,46 @@
     <a href="{{ back_url }}" class="btn btn-outline-secondary">Cancel</a>
   </div>
 </form>
+
+<script>
+// Auto-fill a row's funding amount + 10% contingency from the chosen project's
+// works total. URL has a placeholder pk (0) we swap for the selected project.
+(function () {
+  const urlTemplate = "{% url 'ui:project_works_total' project_pk=0 %}";
+  const num = v => { const n = parseFloat(v); return isNaN(n) ? 0 : n; };
+
+  function rowInputs(projectSelect) {
+    // id looks like id_items-0-project -> prefix "id_items-0-"
+    const prefix = projectSelect.id.replace(/project$/, '');
+    return {
+      funding: document.getElementById(prefix + 'funding_amount'),
+      contingency: document.getElementById(prefix + 'contingency_amount'),
+    };
+  }
+
+  async function onProjectChange(ev) {
+    const sel = ev.target;
+    const pk = sel.value;
+    const { funding, contingency } = rowInputs(sel);
+    if (!pk || !funding) return;
+    // Don't clobber a value the user has already typed.
+    if (num(funding.value) > 0) return;
+    try {
+      const resp = await fetch(urlTemplate.replace('/projects/0/', '/projects/' + pk + '/'));
+      if (!resp.ok) return;
+      const data = await resp.json();
+      if (num(data.works_total) > 0) {
+        funding.value = data.works_total;
+        if (contingency && num(contingency.value) === 0) {
+          contingency.value = data.contingency;
+        }
+      }
+    } catch (e) { /* network/JSON error — leave fields for manual entry */ }
+  }
+
+  document.querySelectorAll('select[id^="id_items-"][id$="-project"]').forEach(sel => {
+    sel.addEventListener('change', onProjectChange);
+  });
+})();
+</script>
 {% endblock %}

--- a/src/apps/ui/templates/brief_financial_approvals/list.html
+++ b/src/apps/ui/templates/brief_financial_approvals/list.html
@@ -1,30 +1,30 @@
 {% extends "base.html" %}
 {% load money %}
-{% block title %}Brief Financial Approvals{% if project %} — {{ project.name }}{% endif %} — RICD{% endblock %}
+{% block title %}Funding Approvals{% if project %} — {{ project.name }}{% endif %} — RICD{% endblock %}
 {% block breadcrumbs %}
   <span class="sep">/</span>
   {% if project %}
     <a href="{% url 'ui:project_detail' project.pk %}">{{ project.name }}</a>
     <span class="sep">/</span>
-    <span class="current">BFAs</span>
+    <span class="current">Funding Approvals</span>
   {% else %}
-    <span class="current">Brief Financial Approvals</span>
+    <span class="current">Funding Approvals</span>
   {% endif %}
 {% endblock %}
 {% block content %}
 <div class="pg-head">
   <div>
-    <h1>Brief Financial Approvals{% if project %} — {{ project.name }}{% endif %}</h1>
+    <h1>Funding Approvals{% if project %} — {{ project.name }}{% endif %}</h1>
     <div class="meta">
       {% if project %}
-        BFAs that include this project (BFAs are grouped under a MINCOR ref and may cover multiple projects).
+        Funding approvals that include this project (grouped under a MINCOR ref, may cover multiple projects).
       {% else %}
-        One BFA per MINCOR reference. Each BFA may cover multiple projects across rows.
+        One funding approval per MINCOR reference. Each may cover multiple projects across rows.
       {% endif %}
     </div>
   </div>
   <div class="actions">
-    <a href="{% url 'ui:bfa_create_global' %}" class="btn btn-primary btn-sm">+ New BFA</a>
+    <a href="{% url 'ui:bfa_create_global' %}" class="btn btn-primary btn-sm">+ New Funding Approval</a>
   </div>
 </div>
 
@@ -58,7 +58,7 @@
         <td class="text-end">{{ bfa.contingency_amount|money }}</td>
         <td class="text-end fw-bold">{{ bfa.total_amount|money }}</td>
         {% endif %}
-        <td>{{ bfa.get_delegate_level_display }}</td>
+        <td>{{ bfa.delegate_position.title|default:"—" }}</td>
         <td>
           {% if bfa.status == 'APPROVED' %}
             <span class="badge bg-success">Approved</span>
@@ -79,7 +79,7 @@
 </div></div>
 {% else %}
 <div class="empty">
-  <p class="text-muted mb-2">No brief financial approvals yet.</p>
+  <p class="text-muted mb-2">No funding approvals yet.</p>
   <a href="{% url 'ui:bfa_create_global' %}" class="btn btn-primary btn-sm">+ Create the first one</a>
 </div>
 {% endif %}

--- a/src/apps/ui/templates/maintenance/delegate_positions.html
+++ b/src/apps/ui/templates/maintenance/delegate_positions.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+{% load money %}
+{% block title %}Delegate Positions — RICD{% endblock %}
+{% block breadcrumbs %}
+  <span class="sep">/</span>
+  <a href="{% url 'ui:maintenance' %}">Maintenance</a>
+  <span class="sep">/</span>
+  <span class="current">Delegate Positions</span>
+{% endblock %}
+{% block content %}
+<div class="pg-head">
+  <div>
+    <h1>Delegate Positions</h1>
+    <div class="meta">Financial delegation positions and the maximum amount each may approve. Used on Funding Approvals.</div>
+  </div>
+  <div class="actions">
+    <a href="{% url 'ui:delegate_position_create' %}" class="btn btn-primary btn-sm">+ Add Position</a>
+  </div>
+</div>
+
+{% if positions %}
+<div class="card"><div class="card-body p-0">
+  <table class="table table-hover mb-0">
+    <thead class="table-light">
+      <tr>
+        <th>Position</th>
+        <th class="text-end">Max approval</th>
+        <th>Active</th>
+        <th>Notes</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for p in positions %}
+      <tr>
+        <td>{{ p.title }}</td>
+        <td class="text-end">{% if p.max_approval_amount %}{{ p.max_approval_amount|money }}{% else %}<span class="text-muted">Unlimited</span>{% endif %}</td>
+        <td>{% if p.is_active %}<span class="badge bg-success">Active</span>{% else %}<span class="badge bg-secondary">Inactive</span>{% endif %}</td>
+        <td class="text-muted" style="font-size:12px;">{{ p.notes|default:"—"|truncatechars:80 }}</td>
+        <td class="text-end">
+          <a href="{% url 'ui:delegate_position_edit' p.pk %}" class="btn btn-sm btn-outline-secondary">Edit</a>
+          <a href="{% url 'ui:delegate_position_delete' p.pk %}" class="btn btn-sm btn-outline-danger">Delete</a>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div></div>
+{% else %}
+<div class="empty">
+  <p class="text-muted mb-2">No delegate positions yet.</p>
+  <a href="{% url 'ui:delegate_position_create' %}" class="btn btn-primary btn-sm">+ Add the first one</a>
+</div>
+{% endif %}
+{% endblock %}

--- a/src/apps/ui/templates/maintenance/index.html
+++ b/src/apps/ui/templates/maintenance/index.html
@@ -368,6 +368,23 @@
   </div>
   {% endif %}
 
+  {# Delegate positions #}
+  <div class="col-sm-6 col-xl-4">
+    <div class="card h-100">
+      <div class="card-body">
+        <div class="ricd-section-title mb-1">
+          <h2><i class="bi bi-person-badge me-1 text-muted"></i>Delegate Positions</h2>
+        </div>
+        <div class="text-muted mb-3" style="font-size:12px">
+          Financial delegation positions and their approval thresholds, used on Funding Approvals.
+        </div>
+        <div class="d-flex gap-2">
+          <a href="{% url 'ui:delegate_position_list' %}" class="btn btn-sm btn-primary">Manage</a>
+        </div>
+      </div>
+    </div>
+  </div>
+
 </div>
 
 {# Feature toggles #}

--- a/src/apps/ui/templates/projects/detail.html
+++ b/src/apps/ui/templates/projects/detail.html
@@ -267,7 +267,7 @@
       <div class="sub">bottom-up from child works</div>
     </div>
     <div class="kpi">
-      <div class="label"><i class="bi bi-cash-stack"></i> Approved (BFA)</div>
+      <div class="label"><i class="bi bi-cash-stack"></i> Approved (Funding)</div>
       <div class="value">{{ total_approved|money }}</div>
       {% if funding_gap > 0 %}
         <div class="sub" style="color:var(--danger,#c0392b);">{{ funding_gap|money_whole }} short — apply for more</div>
@@ -755,12 +755,12 @@
 
     <div class="col-12 mt-2">
       <div class="ricd-section-title">
-        <h2>Brief Financial Approvals</h2>
-        {% if is_fnc %}<a href="{% url 'ui:bfa_create_global' %}" class="btn btn-primary btn-sm"><i class="bi bi-plus"></i> New BFA</a>{% endif %}
+        <h2>Funding Approvals</h2>
+        {% if is_fnc %}<a href="{% url 'ui:bfa_create_global' %}" class="btn btn-primary btn-sm"><i class="bi bi-plus"></i> New Funding Approval</a>{% endif %}
       </div>
       {% with bfas=project.financial_approvals.all %}
       {% if bfas %}
-      <p class="text-muted" style="font-size:12px;">BFAs that include this project. {% if is_council %}Funding shown is this project's approved amount.{% else %}Funding/contingency shown is this project's row in the BFA.{% endif %}</p>
+      <p class="text-muted" style="font-size:12px;">Funding approvals that include this project. {% if is_council %}Funding shown is this project's approved amount.{% else %}Funding/contingency shown is this project's row in the approval.{% endif %}</p>
       <div class="table-responsive">
         <table class="table table-hover align-middle">
           <thead class="table-light">
@@ -774,7 +774,7 @@
                   <td>{{ bfa.mincor_reference|default:"—" }} <span class="text-muted">(#{{ bfa.pk }})</span></td>
                   <td class="text-end">{{ item.funding_amount|money }}</td>
                   {% if not is_council %}<td class="text-end">{% if item.contingency_amount %}{{ item.contingency_amount|money }}{% else %}—{% endif %}</td>{% endif %}
-                  {% if not is_council %}<td>{{ bfa.get_delegate_level_display|default:"—" }}</td>{% endif %}
+                  {% if not is_council %}<td>{{ bfa.delegate_position.title|default:"—" }}</td>{% endif %}
                   <td><span class="state-badge state-{{ bfa.status|lower }}">{{ bfa.get_status_display }}</span></td>
                   {% if not is_council %}<td><a href="{% url 'ui:bfa_detail' bfa.pk %}" class="btn btn-outline-secondary btn-sm">View</a></td>{% endif %}
                 </tr>
@@ -785,7 +785,7 @@
         </table>
       </div>
       {% else %}
-      <p class="text-muted" style="font-size:13px;">No brief financial approvals recorded.</p>
+      <p class="text-muted" style="font-size:13px;">No funding approvals recorded.</p>
       {% endif %}
       {% endwith %}
     </div>

--- a/src/apps/ui/templates/projects/land_detail.html
+++ b/src/apps/ui/templates/projects/land_detail.html
@@ -689,8 +689,8 @@ table.t-works .num-cell{text-align:right;font-variant-numeric:tabular-nums}
 
     <div class="col-12 mt-2">
       <div class="ricd-section-title">
-        <h2>Brief Financial Approvals</h2>
-        {% if is_fnc %}<a href="{% url 'ui:bfa_create_global' %}" class="btn btn-primary btn-sm"><i class="bi bi-plus"></i> New BFA</a>{% endif %}
+        <h2>Funding Approvals</h2>
+        {% if is_fnc %}<a href="{% url 'ui:bfa_create_global' %}" class="btn btn-primary btn-sm"><i class="bi bi-plus"></i> New Funding Approval</a>{% endif %}
       </div>
       {% with bfas=project.financial_approvals.all %}
       {% if bfas %}
@@ -707,7 +707,7 @@ table.t-works .num-cell{text-align:right;font-variant-numeric:tabular-nums}
                   <td>{{ bfa.mincor_reference|default:"—" }} <span class="text-muted">(#{{ bfa.pk }})</span></td>
                   <td class="text-end">{{ item.funding_amount|money }}</td>
                   {% if not is_council %}<td class="text-end">{% if item.contingency_amount %}{{ item.contingency_amount|money }}{% else %}—{% endif %}</td>{% endif %}
-                  {% if not is_council %}<td>{{ bfa.get_delegate_level_display|default:"—" }}</td>{% endif %}
+                  {% if not is_council %}<td>{{ bfa.delegate_position.title|default:"—" }}</td>{% endif %}
                   <td><span class="state-badge state-{{ bfa.status|lower }}">{{ bfa.get_status_display }}</span></td>
                   {% if not is_council %}<td><a href="{% url 'ui:bfa_detail' bfa.pk %}" class="btn btn-outline-secondary btn-sm">View</a></td>{% endif %}
                 </tr>
@@ -718,7 +718,7 @@ table.t-works .num-cell{text-align:right;font-variant-numeric:tabular-nums}
         </table>
       </div>
       {% else %}
-      <p class="text-muted" style="font-size:13px;">No brief financial approvals recorded.</p>
+      <p class="text-muted" style="font-size:13px;">No funding approvals recorded.</p>
       {% endif %}
       {% endwith %}
     </div>

--- a/src/apps/ui/urls.py
+++ b/src/apps/ui/urls.py
@@ -17,6 +17,10 @@ urlpatterns = [
     path('maintenance/', views.crud_views.MaintenanceView.as_view(), name='maintenance'),
     path('maintenance/site-settings/', views.crud_views.SiteSettingsView.as_view(), name='site_settings'),
     path('maintenance/cashflow-rules/', views.crud_views.CashflowRulesView.as_view(), name='cashflow_rules'),
+    path('maintenance/delegate-positions/', views.crud_views.DelegatePositionListView.as_view(), name='delegate_position_list'),
+    path('maintenance/delegate-positions/create/', views.crud_views.DelegatePositionCreateView.as_view(), name='delegate_position_create'),
+    path('maintenance/delegate-positions/<int:pk>/edit/', views.crud_views.DelegatePositionUpdateView.as_view(), name='delegate_position_edit'),
+    path('maintenance/delegate-positions/<int:pk>/delete/', views.crud_views.DelegatePositionDeleteView.as_view(), name='delegate_position_delete'),
     path('maintenance/email-templates/', views.crud_views.EmailTemplateListView.as_view(), name='email_template_list'),
     path('maintenance/email-templates/<int:pk>/edit/', views.crud_views.EmailTemplateUpdateView.as_view(), name='email_template_edit'),
     path('maintenance/notifications-log/', views.crud_views.NotificationLogView.as_view(), name='notification_log'),
@@ -209,6 +213,8 @@ urlpatterns = [
     path('bfa/<int:pk>/delete/', views.crud_views.BriefFinancialApprovalDeleteView.as_view(), name='bfa_delete'),
     path('bfa/<int:pk>/approve/', views.crud_views.BriefFinancialApprovalApproveView.as_view(), name='bfa_approve'),
     path('bfa/<int:pk>/reject/', views.crud_views.BriefFinancialApprovalRejectView.as_view(), name='bfa_reject'),
+    # AJAX: a project's estimated works total (powers Funding Approval auto-fill)
+    path('projects/<int:project_pk>/works-total.json', views.crud_views.ProjectWorksTotalView.as_view(), name='project_works_total'),
     # Legacy per-project BFA list (project-detail page links here to see BFAs containing this project)
     path('projects/<int:project_pk>/bfa/', views.crud_views.BriefFinancialApprovalListView.as_view(), name='bfa_list'),
     # Compat alias: old per-project create URL -> global create form

--- a/src/apps/ui/views/crud_views.py
+++ b/src/apps/ui/views/crud_views.py
@@ -32,7 +32,7 @@ from apps.core.models import (
     FundingAgreement, FundingNotice, ExpenseClaim, WorkFunding,
     StateElectorate, FederalElectorate, QhigiRegion,
     SiteSettings, PaymentMilestoneSchedule, PaymentMilestoneRule, Contractor,
-    EmailTemplate, SentNotification,
+    EmailTemplate, SentNotification, DelegatePosition,
 )
 
 COUNCIL_ROLES = frozenset({'COUNCIL_USER', 'COUNCIL_MANAGER'})
@@ -1884,6 +1884,20 @@ class ExpenseClaimRejectView(FNCOnlyMixin, View):
 # BriefFinancialApproval  (nested under project)
 # ---------------------------------------------------------------------------
 
+def _scope_delegate_position(form):
+    """Limit the delegate_position dropdown to active positions (keep the
+    current value if an inactive one is already set on an edit)."""
+    field = form.fields.get('delegate_position')
+    if not field:
+        return
+    from apps.core.models import DelegatePosition
+    qs = DelegatePosition.objects.filter(is_active=True)
+    current = getattr(form.instance, 'delegate_position_id', None)
+    if current:
+        qs = qs | DelegatePosition.objects.filter(pk=current)
+    field.queryset = qs.distinct()
+
+
 def _bfa_item_formset_factory():
     """Inline formset for BFA -> items.
 
@@ -1933,8 +1947,13 @@ class BriefFinancialApprovalListView(InternalOnlyMixin, ListView):
 class BriefFinancialApprovalCreateView(WriteRequiredMixin, WidgetUpgradeMixin, CreateView):
     model = BriefFinancialApproval
     template_name = 'brief_financial_approvals/form.html'
-    fields = ['mincor_reference', 'document_uri', 'human_rights_assessment_uri', 'delegate_level', 'comments']
+    fields = ['mincor_reference', 'document_uri', 'human_rights_assessment_uri', 'delegate_position', 'comments']
     success_url = reverse_lazy('ui:bfa_global_list')
+
+    def get_form(self, form_class=None):
+        form = super().get_form(form_class)
+        _scope_delegate_position(form)
+        return form
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
@@ -1943,7 +1962,7 @@ class BriefFinancialApprovalCreateView(WriteRequiredMixin, WidgetUpgradeMixin, C
             ctx['items_formset'] = FormSet(self.request.POST, instance=self.object)
         else:
             ctx['items_formset'] = FormSet(instance=self.object)
-        ctx['title'] = 'Create Brief Financial Approval'
+        ctx['title'] = 'Create Funding Approval'
         ctx['back_url'] = reverse_lazy('ui:bfa_global_list')
         return ctx
 
@@ -1976,7 +1995,12 @@ class BriefFinancialApprovalDetailView(InternalOnlyMixin, NoticesMixin, DetailVi
 class BriefFinancialApprovalUpdateView(WriteRequiredMixin, WidgetUpgradeMixin, UpdateView):
     model = BriefFinancialApproval
     template_name = 'brief_financial_approvals/form.html'
-    fields = ['mincor_reference', 'document_uri', 'human_rights_assessment_uri', 'delegate_level', 'comments']
+    fields = ['mincor_reference', 'document_uri', 'human_rights_assessment_uri', 'delegate_position', 'comments']
+
+    def get_form(self, form_class=None):
+        form = super().get_form(form_class)
+        _scope_delegate_position(form)
+        return form
 
     def get_success_url(self):
         return reverse_lazy('ui:bfa_detail', kwargs={'pk': self.object.pk})
@@ -1988,7 +2012,7 @@ class BriefFinancialApprovalUpdateView(WriteRequiredMixin, WidgetUpgradeMixin, U
             ctx['items_formset'] = FormSet(self.request.POST, instance=self.object)
         else:
             ctx['items_formset'] = FormSet(instance=self.object)
-        ctx['title'] = f'Edit Brief Financial Approval #{self.object.pk}'
+        ctx['title'] = f'Edit Funding Approval #{self.object.pk}'
         ctx['back_url'] = reverse_lazy('ui:bfa_detail', kwargs={'pk': self.object.pk})
         return ctx
 
@@ -3850,6 +3874,80 @@ class CashflowRulesView(LoginRequiredMixin, View):
             rule.save()
         messages.success(request, 'Cashflow forecasting rules updated.')
         return redirect('ui:cashflow_rules')
+
+
+# ---------------------------------------------------------------------------
+# Delegate positions (maintenance) — financial delegation thresholds for
+# Funding Approvals. Replaces the old hardcoded delegate-level choices.
+# ---------------------------------------------------------------------------
+
+class DelegatePositionListView(WriteRequiredMixin, ListView):
+    model = DelegatePosition
+    template_name = 'maintenance/delegate_positions.html'
+    context_object_name = 'positions'
+    extra_context = {'active_nav': 'maintenance'}
+
+
+class DelegatePositionCreateView(WriteRequiredMixin, WidgetUpgradeMixin, CreateView):
+    model = DelegatePosition
+    template_name = 'crud/form.html'
+    fields = ['title', 'max_approval_amount', 'is_active', 'order', 'notes']
+    success_url = reverse_lazy('ui:delegate_position_list')
+    extra_context = {'active_nav': 'maintenance'}
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['title'] = 'Add Delegate Position'
+        ctx['back_url'] = reverse_lazy('ui:delegate_position_list')
+        return ctx
+
+
+class DelegatePositionUpdateView(WriteRequiredMixin, WidgetUpgradeMixin, UpdateView):
+    model = DelegatePosition
+    template_name = 'crud/form.html'
+    fields = ['title', 'max_approval_amount', 'is_active', 'order', 'notes']
+    success_url = reverse_lazy('ui:delegate_position_list')
+    extra_context = {'active_nav': 'maintenance'}
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['title'] = f'Edit Delegate Position: {self.object.title}'
+        ctx['back_url'] = reverse_lazy('ui:delegate_position_list')
+        return ctx
+
+
+class DelegatePositionDeleteView(WriteRequiredMixin, DeleteView):
+    model = DelegatePosition
+    template_name = 'crud/confirm_delete.html'
+    success_url = reverse_lazy('ui:delegate_position_list')
+    extra_context = {'active_nav': 'maintenance'}
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['back_url'] = reverse_lazy('ui:delegate_position_list')
+        return ctx
+
+
+class ProjectWorksTotalView(InternalOnlyMixin, View):
+    """JSON: a project's estimated works total (sum of estimated_cost x quantity),
+    a 10% contingency, and the grand total. Powers the Funding Approval form's
+    auto-fill when a project is selected."""
+
+    def get(self, request, project_pk):
+        from decimal import Decimal
+        from django.db.models import Sum, F
+        from django.http import JsonResponse
+        from apps.core.models import Work
+        works_total = Work.objects.filter(project_id=project_pk).aggregate(
+            total=Sum(F('estimated_cost') * F('quantity'))
+        )['total'] or Decimal('0')
+        contingency = (works_total * Decimal('0.10')).quantize(Decimal('0.01'))
+        return JsonResponse({
+            'project_pk': project_pk,
+            'works_total': str(works_total),
+            'contingency': str(contingency),
+            'total': str(works_total + contingency),
+        })
 
 
 class EmailTemplateListView(WriteRequiredMixin, ListView):

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -390,7 +390,7 @@
   </a>
   {% if not is_council %}
   <a href="{% url 'ui:bfa_global_list' %}" class="nav-item {% if active_nav == 'bfa' %}active{% endif %}">
-    <i class="bi bi-receipt-cutoff"></i> BFA
+    <i class="bi bi-receipt-cutoff"></i> Funding Approvals
   </a>
   {% endif %}
   <a href="{% url 'ui:funding_notice_list' %}" class="nav-item {% if active_nav == 'funding_notices' %}active{% endif %}">

--- a/tests/e2e_full_payment_workflow.py
+++ b/tests/e2e_full_payment_workflow.py
@@ -47,7 +47,7 @@ class TestEndToEndPaymentWorkflow:
         from tests.fixtures import make_bfa
         bfa = make_bfa(
             project, Decimal("1000000.00"),
-            delegate_level="MGR", status="PENDING",
+            status="PENDING",
         )
         assert bfa.status == "PENDING"
 
@@ -160,7 +160,7 @@ class TestEndToEndPaymentWorkflow:
         from tests.fixtures import make_bfa
         bfa = make_bfa(
             project, Decimal("3000000.00"),
-            delegate_level="MGR", status="APPROVED", approved_by=manager,
+            status="APPROVED", approved_by=manager,
         )
 
         # Create Agreement and Schedule
@@ -273,7 +273,7 @@ class TestEndToEndPaymentWorkflow:
         from tests.fixtures import make_bfa
         bfa = make_bfa(
             project, Decimal("2000000.00"),
-            delegate_level="MGR", status="APPROVED", approved_by=manager,
+            status="APPROVED", approved_by=manager,
         )
 
         # Original schedule

--- a/tests/test_bfa_crud.py
+++ b/tests/test_bfa_crud.py
@@ -6,8 +6,15 @@ from decimal import Decimal
 from django.test import Client
 from django.contrib.auth.models import User
 from apps.core.models import (
-    BriefFinancialApproval, BriefFinancialApprovalItem, Profile,
+    BriefFinancialApproval, BriefFinancialApprovalItem, Profile, DelegatePosition,
 )
+
+
+@pytest.fixture
+def director_position():
+    # 'Director' is seeded by migration 0051 — reuse it rather than duplicate.
+    return DelegatePosition.objects.get_or_create(
+        title='Director', defaults={'max_approval_amount': Decimal('1000000'), 'order': 2})[0]
 
 
 @pytest.fixture
@@ -24,7 +31,6 @@ def bfa(project):
     """BFA header with one item row for `project`."""
     bfa = BriefFinancialApproval.objects.create(
         mincor_reference='MINCOR-TEST',
-        delegate_level=BriefFinancialApproval.DelegateLevel.MANAGER,
         status=BriefFinancialApproval.Status.PENDING,
     )
     BriefFinancialApprovalItem.objects.create(
@@ -68,13 +74,13 @@ class TestBFACreate:
         client, _ = auth_client
         assert client.get('/bfa/create/').status_code == 200
 
-    def test_create_post_with_one_item(self, auth_client, council, project):
+    def test_create_post_with_one_item(self, auth_client, council, project, director_position):
         client, _ = auth_client
         before = BriefFinancialApproval.objects.count()
         response = client.post('/bfa/create/', {
             'mincor_reference': 'MINCOR-001',
             'document_uri': 'https://example.com/brief.pdf',
-            'delegate_level': 'DIR',
+            'delegate_position': director_position.pk,
             'comments': 'Test approval',
             'items-TOTAL_FORMS': '1',
             'items-INITIAL_FORMS': '0',
@@ -92,6 +98,7 @@ class TestBFACreate:
         assert bfa is not None
         assert bfa.project_count == 1
         assert bfa.funding_amount == Decimal('750000')
+        assert bfa.delegate_position == director_position
 
 
 @pytest.mark.django_db
@@ -121,13 +128,13 @@ class TestBFAEdit:
         client, _ = auth_client
         assert client.get(f'/bfa/{bfa.pk}/edit/').status_code == 200
 
-    def test_edit_post_updates_object(self, auth_client, bfa, project):
+    def test_edit_post_updates_object(self, auth_client, bfa, project, director_position):
         client, _ = auth_client
         item = bfa.items.first()
         client.post(f'/bfa/{bfa.pk}/edit/', {
             'mincor_reference': 'MINCOR-UPDATED',
             'document_uri': '',
-            'delegate_level': 'DIR',
+            'delegate_position': director_position.pk,
             'comments': '',
             'items-TOTAL_FORMS': '1',
             'items-INITIAL_FORMS': '1',
@@ -143,7 +150,7 @@ class TestBFAEdit:
         })
         bfa.refresh_from_db()
         assert bfa.mincor_reference == 'MINCOR-UPDATED'
-        assert bfa.delegate_level == 'DIR'
+        assert bfa.delegate_position == director_position
         assert bfa.funding_amount == Decimal('600000')
 
 

--- a/tests/test_brief_financial_approval.py
+++ b/tests/test_brief_financial_approval.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 
 from apps.core.models import (
     BriefFinancialApproval, FundingSchedule, FundingAgreement, PaymentRule,
+    DelegatePosition,
 )
 from apps.core.models import Council, Program, Project
 from django.contrib.auth.models import User
@@ -52,10 +53,23 @@ def approver_user():
 
 
 @pytest.fixture
-def approved_bfa(project, approver_user):
+def manager_position():
+    # 'Manager' is seeded by migration 0051 — reuse it rather than duplicate.
+    return DelegatePosition.objects.get_or_create(
+        title="Manager", defaults={'max_approval_amount': Decimal("250000.00"), 'order': 1})[0]
+
+
+@pytest.fixture
+def director_position():
+    return DelegatePosition.objects.get_or_create(
+        title="Director", defaults={'max_approval_amount': Decimal("1000000.00"), 'order': 2})[0]
+
+
+@pytest.fixture
+def approved_bfa(project, approver_user, manager_position):
     return make_bfa(
         project, Decimal("500000.00"),
-        delegate_level=BriefFinancialApproval.DelegateLevel.MANAGER,
+        delegate_position=manager_position,
         status="APPROVED",
         approved_by=approver_user,
         mincor_reference="MINCOR-2026-001",
@@ -63,10 +77,10 @@ def approved_bfa(project, approver_user):
 
 
 @pytest.fixture
-def pending_bfa(project):
+def pending_bfa(project, director_position):
     return make_bfa(
         project, Decimal("750000.00"),
-        delegate_level=BriefFinancialApproval.DelegateLevel.DIRECTOR,
+        delegate_position=director_position,
         status="PENDING",
     )
 
@@ -98,13 +112,13 @@ class TestBriefFinancialApprovalCreation:
         assert pending_bfa.id is not None
         assert pending_bfa.status == "PENDING"
         assert pending_bfa.funding_amount == Decimal("750000.00")
-        assert pending_bfa.delegate_level == BriefFinancialApproval.DelegateLevel.DIRECTOR
+        assert pending_bfa.delegate_position.title == "Director"
         assert pending_bfa.approved_by is None
 
-    def test_create_approved_bfa(self, project, approver_user):
+    def test_create_approved_bfa(self, project, approver_user, manager_position):
         bfa = make_bfa(
             project, Decimal("500000.00"),
-            delegate_level=BriefFinancialApproval.DelegateLevel.MANAGER,
+            delegate_position=manager_position,
             status="APPROVED",
             approved_by=approver_user,
             mincor_reference="MINCOR-2026-001",
@@ -119,7 +133,7 @@ class TestBriefFinancialApprovalCreation:
     def test_rejected_bfa(self, project):
         rejection = make_bfa(
             project, Decimal("600000.00"),
-            delegate_level="GM", status="REJECTED",
+            status="REJECTED",
         )
         assert rejection.status == "REJECTED"
 
@@ -163,26 +177,30 @@ class TestBriefFinancialApprovalPreCondition:
 
 
 @pytest.mark.django_db
-class TestBriefFinancialApprovalDelegateLevels:
-    def test_manager_level(self, project, approver_user):
+class TestBriefFinancialApprovalDelegatePositions:
+    def test_manager_position(self, project, approver_user, manager_position):
         bfa = make_bfa(
             project, Decimal("200000.00"),
-            delegate_level=BriefFinancialApproval.DelegateLevel.MANAGER,
+            delegate_position=manager_position,
             status="APPROVED", approved_by=approver_user,
         )
-        assert bfa.delegate_level == BriefFinancialApproval.DelegateLevel.MANAGER
+        assert bfa.delegate_position == manager_position
+        assert bfa.delegate_position.title == "Manager"
 
-    def test_director_level(self, project, approver_user):
+    def test_director_position(self, project, approver_user, director_position):
         bfa = make_bfa(
             project, Decimal("600000.00"),
-            delegate_level=BriefFinancialApproval.DelegateLevel.DIRECTOR,
+            delegate_position=director_position,
             status="APPROVED", approved_by=approver_user,
         )
-        assert bfa.delegate_level == BriefFinancialApproval.DelegateLevel.DIRECTOR
+        assert bfa.delegate_position.title == "Director"
 
-    def test_gm_level(self, project, approver_user):
+    def test_position_cleared_on_delete(self, project, approver_user, manager_position):
         bfa = make_bfa(
-            project, Decimal("2000000.00"),
-            delegate_level="GM", status="APPROVED", approved_by=approver_user,
+            project, Decimal("200000.00"),
+            delegate_position=manager_position,
+            status="APPROVED", approved_by=approver_user,
         )
-        assert bfa.delegate_level == "GM"
+        manager_position.delete()
+        bfa.refresh_from_db()
+        assert bfa.delegate_position is None

--- a/tests/test_delegate_positions.py
+++ b/tests/test_delegate_positions.py
@@ -1,0 +1,61 @@
+"""Delegate positions (maintenance CRUD) + Funding Approval works-total auto-fill."""
+import json
+from decimal import Decimal
+
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_works_total_endpoint(admin_client, work, project):
+    # `work` fixture: quantity 2 x $250,000 = $500,000; 10% contingency = $50,000.
+    url = reverse('ui:project_works_total', kwargs={'project_pk': project.pk})
+    resp = admin_client.get(url)
+    assert resp.status_code == 200
+    data = json.loads(resp.content)
+    assert Decimal(data['works_total']) == Decimal('500000')
+    assert Decimal(data['contingency']) == Decimal('50000.00')
+    assert Decimal(data['total']) == Decimal('550000.00')
+
+
+@pytest.mark.django_db
+def test_works_total_zero_when_no_works(admin_client, project):
+    url = reverse('ui:project_works_total', kwargs={'project_pk': project.pk})
+    data = json.loads(admin_client.get(url).content)
+    assert Decimal(data['works_total']) == Decimal('0')
+    assert Decimal(data['contingency']) == Decimal('0')
+
+
+@pytest.mark.django_db
+def test_delegate_position_list_renders(admin_client):
+    # Migration 0051 seeds Manager / Director / General Manager.
+    resp = admin_client.get(reverse('ui:delegate_position_list'))
+    assert resp.status_code == 200
+    body = resp.content.decode()
+    assert 'Manager' in body
+    assert 'Director' in body
+
+
+@pytest.mark.django_db
+def test_delegate_position_create(admin_client):
+    from apps.core.models import DelegatePosition
+    resp = admin_client.post(reverse('ui:delegate_position_create'), {
+        'title': 'Executive Director',
+        'max_approval_amount': '5000000',
+        'is_active': 'on',
+        'order': '4',
+        'notes': 'High-value approvals.',
+    })
+    assert resp.status_code == 302
+    p = DelegatePosition.objects.get(title='Executive Director')
+    assert p.max_approval_amount == Decimal('5000000')
+
+
+@pytest.mark.django_db
+def test_funding_approval_form_lists_active_positions_only(admin_client):
+    from apps.core.models import DelegatePosition
+    DelegatePosition.objects.filter(title='Director').update(is_active=False)
+    body = admin_client.get(reverse('ui:bfa_create_global')).content.decode()
+    # Active seeded position present; the inactivated one is not offered.
+    assert 'Manager' in body
+    assert 'Director' not in body

--- a/tests/test_funding_schedule_lifecycle.py
+++ b/tests/test_funding_schedule_lifecycle.py
@@ -46,7 +46,7 @@ def approved_bfa(project):
     from tests.fixtures import make_bfa
     return make_bfa(
         project, Decimal("1000000.00"),
-        delegate_level="MGR", status="APPROVED", approved_by=user,
+        status="APPROVED", approved_by=user,
     )
 
 

--- a/tests/test_issue_32_drf_api.py
+++ b/tests/test_issue_32_drf_api.py
@@ -62,7 +62,6 @@ def _make_bfa(project, status='PENDING'):
     from tests.fixtures import make_bfa
     return make_bfa(
         project, Decimal('500000'),
-        delegate_level=BriefFinancialApproval.DelegateLevel.MANAGER,
         status=status,
     )
 


### PR DESCRIPTION
…, auto-fill from works

- Display rename "BFA"/"Brief Financial Approval" -> "Funding Approval" across nav, the three approval pages, and project/land detail sections. Internal names (URLs, model, views) unchanged.
- Replace the hardcoded BFA delegate-level enum with a DelegatePosition model (title, max approval amount, active, order, notes) + Maintenance CRUD. Migration 0051 seeds Manager/Director/General Manager and maps existing approvals across; delegate_position FK is SET_NULL.
- New /projects/<pk>/works-total.json endpoint (sum of estimated_cost x quantity, 10% contingency, total). The Funding Approval form auto-fills a row's funding amount + contingency when a project is picked, without clobbering values already typed.
- Update admin, DRF serializer, domain-model doc, and all affected tests; add tests/test_delegate_positions.py. Full suite: 663 passed.

## Summary
Explain what this PR does and why.

Fixes #<issue_number>  <!-- Link the issue this PR resolves -->

## Changes
- [x] Describe key changes (models, views, forms, etc.)
- [x] Add migrations if applicable
- [x] Update tests / add new ones

## Testing
Describe how you tested the changes:
- [ ] Ran `python manage.py check`
- [ ] Verified `runserver` starts successfully
- [ ] Manual browser test on affected routes
- [ ] Unit tests pass (`pytest` or Django test suite)

## Notes
Anything reviewers or Roo Code should be aware of (e.g. partial fixes, TODOs, dependencies).