### PR TITLE
fix: CSRF trusted origins + setup_groups command + help page updates

### DIFF
--- a/src/apps/core/management/commands/setup_groups.py
+++ b/src/apps/core/management/commands/setup_groups.py
@@ -1,0 +1,210 @@
+"""
+Management command: python manage.py setup_groups
+
+Creates (or updates) the five RICD permission groups with appropriate
+Django model-level permissions. Safe to re-run — uses get_or_create.
+
+Groups mirror the five officer_role values on Profile:
+  RICD Officer       — FNC frontline, full CRUD on all delivery/funding records
+  RICD Manager       — FNC senior, everything Officer can + delete + site config
+  Council Officer    — Council staff, view own-council records + submit reports
+  Council Manager    — Senior council staff, same scope as Council Officer
+  Read Only          — Audit/finance/exec, view everything, no writes
+"""
+from django.contrib.auth.models import Group, Permission
+from django.core.management.base import BaseCommand
+
+from apps.core.models import GroupPermission
+
+
+VIEW = ['view']
+ADD_CHANGE_VIEW = ['add', 'change', 'view']
+FULL = ['add', 'change', 'delete', 'view']
+
+
+def _build_codenames(entries, actions):
+    return {f'{app}.{action}_{model}' for app, model in entries for action in actions}
+
+
+# Models visible to all roles (view only unless overridden below).
+_ALL_VIEW = [
+    ('core', 'council'), ('core', 'program'), ('core', 'project'),
+    ('core', 'address'), ('core', 'work'), ('core', 'workstep'),
+    ('core', 'worktype'), ('core', 'workstepgroup'), ('core', 'workstepdefinition'),
+    ('core', 'fundingagreement'), ('core', 'fundingschedule'),
+    ('core', 'payment'), ('core', 'paymentrule'),
+    ('core', 'paymentmilestoneschedule'), ('core', 'paymentmilestonerule'),
+    ('core', 'approval'), ('core', 'variation'), ('core', 'variationitem'),
+    ('core', 'monthlytrackerentry'), ('core', 'quarterlyreport'),
+    ('core', 'stagereport'), ('core', 'fundingnotice'), ('core', 'expenseclaim'),
+    ('core', 'workfunding'), ('core', 'brieffinancialapproval'),
+    ('core', 'brieffinancialapprovalitem'), ('core', 'document'),
+    ('core', 'comment'), ('core', 'landtenure'), ('core', 'suburb'),
+]
+
+# Delivery + funding records Officers can create/edit (not delete).
+_OFFICER_WRITE = [
+    ('core', 'project'), ('core', 'address'), ('core', 'work'), ('core', 'workstep'),
+    ('core', 'fundingagreement'), ('core', 'fundingschedule'),
+    ('core', 'payment'), ('core', 'paymentrule'),
+    ('core', 'approval'), ('core', 'variation'), ('core', 'variationitem'),
+    ('core', 'monthlytrackerentry'), ('core', 'quarterlyreport'),
+    ('core', 'stagereport'), ('core', 'fundingnotice'), ('core', 'expenseclaim'),
+    ('core', 'workfunding'), ('core', 'brieffinancialapproval'),
+    ('core', 'brieffinancialapprovalitem'), ('core', 'document'), ('core', 'comment'),
+]
+
+# Reference/lookup tables Officers can also edit.
+_OFFICER_REF = [
+    ('core', 'worktype'), ('core', 'workstepgroup'), ('core', 'workstepdefinition'),
+    ('core', 'paymentmilestoneschedule'), ('core', 'paymentmilestonerule'),
+    ('core', 'landtenure'), ('core', 'suburb'),
+]
+
+# Models only Managers can delete.
+_MANAGER_DELETE = [
+    ('core', 'project'), ('core', 'address'), ('core', 'work'),
+    ('core', 'fundingagreement'), ('core', 'fundingschedule'),
+    ('core', 'payment'), ('core', 'brieffinancialapproval'),
+    ('core', 'variation'), ('core', 'document'),
+]
+
+# Site/user admin only Managers can touch.
+_MANAGER_ADMIN = [
+    ('core', 'sitesettings'), ('core', 'profile'), ('core', 'grouppermission'),
+    ('auth', 'user'), ('auth', 'group'),
+]
+
+# What council roles can view (no BFA / funding internals).
+_COUNCIL_VIEW = [
+    ('core', 'council'), ('core', 'program'), ('core', 'project'),
+    ('core', 'address'), ('core', 'work'), ('core', 'workstep'),
+    ('core', 'worktype'), ('core', 'fundingschedule'), ('core', 'payment'),
+    ('core', 'approval'), ('core', 'variation'), ('core', 'variationitem'),
+    ('core', 'monthlytrackerentry'), ('core', 'quarterlyreport'),
+    ('core', 'stagereport'), ('core', 'fundingnotice'), ('core', 'expenseclaim'),
+    ('core', 'workfunding'), ('core', 'document'), ('core', 'comment'),
+    ('core', 'landtenure'), ('core', 'suburb'),
+]
+
+# What council roles can submit/create.
+_COUNCIL_WRITE = [
+    ('core', 'monthlytrackerentry'), ('core', 'quarterlyreport'),
+    ('core', 'stagereport'), ('core', 'expenseclaim'),
+    ('core', 'document'), ('core', 'comment'),
+]
+
+
+GROUP_SPECS = {
+    'RICD Officer': {
+        'group_type': 'OFFICER',
+        'description': 'FNC frontline staff — full create/edit on all delivery and funding records across all councils.',
+        'can_approve_reports': False,
+        'can_approve_payments': False,
+        'can_manage_councils': False,
+        'can_manage_programs': False,
+        'can_manage_users': False,
+        'codenames': (
+            _build_codenames(_ALL_VIEW, VIEW) |
+            _build_codenames(_OFFICER_WRITE, ADD_CHANGE_VIEW) |
+            _build_codenames(_OFFICER_REF, ADD_CHANGE_VIEW)
+        ),
+    },
+    'RICD Manager': {
+        'group_type': 'MANAGER',
+        'description': 'FNC senior staff — everything Officer can do, plus delete, archive, user management, and site config.',
+        'can_approve_reports': True,
+        'can_approve_payments': True,
+        'can_manage_councils': True,
+        'can_manage_programs': True,
+        'can_manage_users': True,
+        'codenames': (
+            _build_codenames(_ALL_VIEW, VIEW) |
+            _build_codenames(_OFFICER_WRITE, ADD_CHANGE_VIEW) |
+            _build_codenames(_OFFICER_REF, FULL) |
+            _build_codenames(_MANAGER_DELETE, ['delete']) |
+            _build_codenames(_MANAGER_ADMIN, FULL)
+        ),
+    },
+    'Council Officer': {
+        'group_type': 'COUNCIL_USER',
+        'description': 'Council staff — view own-council records only; submit reports and expense claims.',
+        'can_approve_reports': False,
+        'can_approve_payments': False,
+        'can_manage_councils': False,
+        'can_manage_programs': False,
+        'can_manage_users': False,
+        'codenames': (
+            _build_codenames(_COUNCIL_VIEW, VIEW) |
+            _build_codenames(_COUNCIL_WRITE, ADD_CHANGE_VIEW)
+        ),
+    },
+    'Council Manager': {
+        'group_type': 'COUNCIL_MANAGER',
+        'description': 'Senior council staff — same scope as Council Officer (own-council data only).',
+        'can_approve_reports': False,
+        'can_approve_payments': False,
+        'can_manage_councils': False,
+        'can_manage_programs': False,
+        'can_manage_users': False,
+        'codenames': (
+            _build_codenames(_COUNCIL_VIEW, VIEW) |
+            _build_codenames(_COUNCIL_WRITE, ADD_CHANGE_VIEW)
+        ),
+    },
+    'Read Only': {
+        'group_type': 'READ_ONLY',
+        'description': 'Internal audit / finance / executives — read everything across all councils, no writes.',
+        'can_approve_reports': False,
+        'can_approve_payments': False,
+        'can_manage_councils': False,
+        'can_manage_programs': False,
+        'can_manage_users': False,
+        'codenames': _build_codenames(_ALL_VIEW, VIEW),
+    },
+}
+
+
+class Command(BaseCommand):
+    help = 'Create or update RICD permission groups with correct model-level permissions.'
+
+    def handle(self, *args, **options):
+        perm_lookup = {
+            f'{p.content_type.app_label}.{p.codename}': p
+            for p in Permission.objects.select_related('content_type').all()
+        }
+
+        for group_name, spec in GROUP_SPECS.items():
+            group, created = Group.objects.get_or_create(name=group_name)
+            action = 'Created' if created else 'Updated'
+
+            perms, missing = [], []
+            for codename in spec['codenames']:
+                p = perm_lookup.get(codename)
+                if p:
+                    perms.append(p)
+                else:
+                    missing.append(codename)
+
+            group.permissions.set(perms)
+
+            gp, _ = GroupPermission.objects.get_or_create(group=group)
+            gp.group_type = spec['group_type']
+            gp.description = spec['description']
+            gp.can_approve_reports = spec['can_approve_reports']
+            gp.can_approve_payments = spec['can_approve_payments']
+            gp.can_manage_councils = spec['can_manage_councils']
+            gp.can_manage_programs = spec['can_manage_programs']
+            gp.can_manage_users = spec['can_manage_users']
+            gp.save()
+
+            self.stdout.write(self.style.SUCCESS(
+                f'{action} "{group_name}" — {len(perms)} permissions assigned.'
+            ))
+            if missing:
+                self.stdout.write(self.style.WARNING(
+                    f'  Skipped {len(missing)} unknown codenames: '
+                    f'{", ".join(sorted(missing)[:5])}{"…" if len(missing) > 5 else ""}'
+                ))
+
+        self.stdout.write(self.style.SUCCESS('\nDone. Safe to re-run any time to resync.'))

--- a/src/apps/ui/templates/help/index.html
+++ b/src/apps/ui/templates/help/index.html
@@ -165,7 +165,7 @@
       <h3>Portfolio</h3>
       <ul>
         <li><strong>Dashboard</strong> — portfolio totals, project status (on-track / late / overdue), budget, filters by council/program/status.</li>
-        <li><strong>Projects</strong> — each project's overview, its child <em>addresses &amp; works</em> (dwellings, lots, infrastructure) with costs, funding, payments, reports and documents in tabs.</li>
+        <li><strong>Projects</strong> — each project's overview, its child <em>addresses &amp; works</em> (dwellings, lots, infrastructure) with costs, funding, payments, reports and documents in tabs. The project list hides completed projects by default — tick <em>Include completed projects</em> under the State filter to show them (useful for analytics and past cashflow without cluttering active work).</li>
         <li><strong>Cashflow</strong> — forecast of committed vs released spend per program per financial year (see §6).</li>
         <li><strong>Analytics</strong> — aggregate outputs: how many dwellings by type and bedroom count, residential lots, and their costs, totalled by category, council and program.</li>
       </ul>
@@ -175,13 +175,13 @@
         <li><strong>Funding Agreements</strong> — the legal umbrella with a council.</li>
         <li><strong>Funding Schedules</strong> — the per-project funding instrument with a lifecycle (draft → ready → executed → active → superseded) and key dates that cascade to the project.</li>
         <li><strong>Payment Rules</strong> — immutable, versioned rules defining how a schedule's payments split (e.g. 30/60/10).</li>
-        <li><strong>BFA</strong> <span class="tag fnc">FNC only</span> — Brief Financial Approvals: the pre-condition that releases funding, including per-program splits and contingency.</li>
+        <li><strong>BFA</strong> <span class="tag fnc">FNC only</span> — Brief Financial Approvals: the pre-condition that releases funding, including per-program splits and contingency. The <em>Add Projects</em> button opens a picker showing only projects with a funding shortfall (total works cost exceeds approved BFA funding). A live warning appears if the sum of all row totals exceeds the selected delegate's approval limit.</li>
         <li><strong>Funding Notices &amp; Expense Claims</strong> — the capped-payment pathway; councils can submit claims against a notice.</li>
       </ul>
 
       <h3>Reports</h3>
       <ul>
-        <li><strong>Monthly Trackers</strong> — per-work construction progress grid; entering dates here drives forecasting and (now) payment timing.</li>
+        <li><strong>Monthly Trackers</strong> — per-work construction progress grid; entering dates here drives forecasting and payment timing. The Excel export uses a pivoted layout: one sheet per Work Step Group, rows are addresses/works (showing street address and "N bed Type" on two lines), and columns are the tracker steps. Green = completed (actual date recorded), yellow = fillable, grey = not applicable. Import the filled sheet back to bulk-update progress dates.</li>
         <li><strong>Quarterly Reports</strong> — FS → project → works hierarchy with expenditure and declarations, submitted to the State.</li>
         <li><strong>Stage Reports</strong> — Stage 1 / Stage 2 contract checklists that gate the next payment.</li>
       </ul>
@@ -326,7 +326,7 @@
           "Site establishment" step yet, that payment stays undated until the step (or its date) is recorded.</li>
         <li><strong>Manual always wins.</strong> Setting a payment to Manual, or typing a date, opts it out of automatic rolling.</li>
         <li><strong>Released payments are locked.</strong> Their program allocation is snapshotted at release and never retro-adjusted by later BFA changes.</li>
-        <li><strong>Costs are actual where entered, otherwise notional</strong> (estimated from per-work-type rates) — the Analytics page notes this.</li>
+        <li><strong>Cost fields on a work are per output (per unit), not totals.</strong> There are three tiers in priority order: <em>Estimated cost per output</em> (base, from notional rates or manual entry) → <em>Forecast final cost per output</em> (overrides estimated once entered) → <em>Actual cost per output</em> (authoritative once "Costs finalised" is ticked). The system multiplies whichever tier applies by the work's quantity to get the total. Entering a total instead of a per-unit cost will over-report by a factor of quantity.</li>
         <li><strong>Audit logging is automatic</strong> for financial records and cannot be edited.</li>
       </ul>
       <div class="note">

--- a/src/ricdapp/settings.py
+++ b/src/ricdapp/settings.py
@@ -158,6 +158,10 @@ X_FRAME_OPTIONS = 'DENY'
 SECURE_CONTENT_TYPE_NOSNIFF = True
 CSRF_COOKIE_HTTPONLY = True
 
+_csrf_trusted = os.environ.get('DJANGO_CSRF_TRUSTED_ORIGINS', '')
+if _csrf_trusted:
+    CSRF_TRUSTED_ORIGINS = [o.strip() for o in _csrf_trusted.split(',') if o.strip()]
+
 if not DEBUG:
     SECURE_SSL_REDIRECT = True
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')


### PR DESCRIPTION
## Summary

- **CSRF fix** (`settings.py`): reads `DJANGO_CSRF_TRUSTED_ORIGINS` from environment — required for HTTPS reverse proxy deployments. Add to `.env`: `DJANGO_CSRF_TRUSTED_ORIGINS=https://ricd.nolanholmes.com`
- **`setup_groups` management command**: creates/updates five Django permission groups with correct model-level permissions. Run once after deploy: `python manage.py setup_groups`
  - RICD Officer — full create/edit on all delivery + funding records
  - RICD Manager — everything Officer + delete + user/site management
  - Council Officer — view own-council records + submit reports/claims
  - Council Manager — same scope as Council Officer
  - Read Only — view everything, no writes
- **Help page** (`/help/`): updated §4 (BFA project picker, completed-projects filter), §7 (pivoted monthly tracker Excel layout), §9 (cost per-output hierarchy warning)

## Test plan

- [ ] Merge + `ricd update` on VM — confirm login works without CSRF error
- [ ] `python src/manage.py setup_groups` — confirm 5 groups created with no errors
- [ ] Django admin → Groups — confirm all 5 groups appear with permissions populated
- [ ] Visit `/help/` — confirm BFA, Projects, tracker, and cost sections are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)