### PR TITLE
feat: PC forecast exclusion flag + CSRF fix + setup_groups + help updates

### DIFF
--- a/src/apps/core/management/commands/setup_groups.py
+++ b/src/apps/core/management/commands/setup_groups.py
@@ -1,0 +1,210 @@
+"""
+Management command: python manage.py setup_groups
+
+Creates (or updates) the five RICD permission groups with appropriate
+Django model-level permissions. Safe to re-run — uses get_or_create.
+
+Groups mirror the five officer_role values on Profile:
+  RICD Officer       — FNC frontline, full CRUD on all delivery/funding records
+  RICD Manager       — FNC senior, everything Officer can + delete + site config
+  Council Officer    — Council staff, view own-council records + submit reports
+  Council Manager    — Senior council staff, same scope as Council Officer
+  Read Only          — Audit/finance/exec, view everything, no writes
+"""
+from django.contrib.auth.models import Group, Permission
+from django.core.management.base import BaseCommand
+
+from apps.core.models import GroupPermission
+
+
+VIEW = ['view']
+ADD_CHANGE_VIEW = ['add', 'change', 'view']
+FULL = ['add', 'change', 'delete', 'view']
+
+
+def _build_codenames(entries, actions):
+    return {f'{app}.{action}_{model}' for app, model in entries for action in actions}
+
+
+# Models visible to all roles (view only unless overridden below).
+_ALL_VIEW = [
+    ('core', 'council'), ('core', 'program'), ('core', 'project'),
+    ('core', 'address'), ('core', 'work'), ('core', 'workstep'),
+    ('core', 'worktype'), ('core', 'workstepgroup'), ('core', 'workstepdefinition'),
+    ('core', 'fundingagreement'), ('core', 'fundingschedule'),
+    ('core', 'payment'), ('core', 'paymentrule'),
+    ('core', 'paymentmilestoneschedule'), ('core', 'paymentmilestonerule'),
+    ('core', 'approval'), ('core', 'variation'), ('core', 'variationitem'),
+    ('core', 'monthlytrackerentry'), ('core', 'quarterlyreport'),
+    ('core', 'stagereport'), ('core', 'fundingnotice'), ('core', 'expenseclaim'),
+    ('core', 'workfunding'), ('core', 'brieffinancialapproval'),
+    ('core', 'brieffinancialapprovalitem'), ('core', 'document'),
+    ('core', 'comment'), ('core', 'landtenure'), ('core', 'suburb'),
+]
+
+# Delivery + funding records Officers can create/edit (not delete).
+_OFFICER_WRITE = [
+    ('core', 'project'), ('core', 'address'), ('core', 'work'), ('core', 'workstep'),
+    ('core', 'fundingagreement'), ('core', 'fundingschedule'),
+    ('core', 'payment'), ('core', 'paymentrule'),
+    ('core', 'approval'), ('core', 'variation'), ('core', 'variationitem'),
+    ('core', 'monthlytrackerentry'), ('core', 'quarterlyreport'),
+    ('core', 'stagereport'), ('core', 'fundingnotice'), ('core', 'expenseclaim'),
+    ('core', 'workfunding'), ('core', 'brieffinancialapproval'),
+    ('core', 'brieffinancialapprovalitem'), ('core', 'document'), ('core', 'comment'),
+]
+
+# Reference/lookup tables Officers can also edit.
+_OFFICER_REF = [
+    ('core', 'worktype'), ('core', 'workstepgroup'), ('core', 'workstepdefinition'),
+    ('core', 'paymentmilestoneschedule'), ('core', 'paymentmilestonerule'),
+    ('core', 'landtenure'), ('core', 'suburb'),
+]
+
+# Models only Managers can delete.
+_MANAGER_DELETE = [
+    ('core', 'project'), ('core', 'address'), ('core', 'work'),
+    ('core', 'fundingagreement'), ('core', 'fundingschedule'),
+    ('core', 'payment'), ('core', 'brieffinancialapproval'),
+    ('core', 'variation'), ('core', 'document'),
+]
+
+# Site/user admin only Managers can touch.
+_MANAGER_ADMIN = [
+    ('core', 'sitesettings'), ('core', 'profile'), ('core', 'grouppermission'),
+    ('auth', 'user'), ('auth', 'group'),
+]
+
+# What council roles can view (no BFA / funding internals).
+_COUNCIL_VIEW = [
+    ('core', 'council'), ('core', 'program'), ('core', 'project'),
+    ('core', 'address'), ('core', 'work'), ('core', 'workstep'),
+    ('core', 'worktype'), ('core', 'fundingschedule'), ('core', 'payment'),
+    ('core', 'approval'), ('core', 'variation'), ('core', 'variationitem'),
+    ('core', 'monthlytrackerentry'), ('core', 'quarterlyreport'),
+    ('core', 'stagereport'), ('core', 'fundingnotice'), ('core', 'expenseclaim'),
+    ('core', 'workfunding'), ('core', 'document'), ('core', 'comment'),
+    ('core', 'landtenure'), ('core', 'suburb'),
+]
+
+# What council roles can submit/create.
+_COUNCIL_WRITE = [
+    ('core', 'monthlytrackerentry'), ('core', 'quarterlyreport'),
+    ('core', 'stagereport'), ('core', 'expenseclaim'),
+    ('core', 'document'), ('core', 'comment'),
+]
+
+
+GROUP_SPECS = {
+    'RICD Officer': {
+        'group_type': 'OFFICER',
+        'description': 'FNC frontline staff — full create/edit on all delivery and funding records across all councils.',
+        'can_approve_reports': False,
+        'can_approve_payments': False,
+        'can_manage_councils': False,
+        'can_manage_programs': False,
+        'can_manage_users': False,
+        'codenames': (
+            _build_codenames(_ALL_VIEW, VIEW) |
+            _build_codenames(_OFFICER_WRITE, ADD_CHANGE_VIEW) |
+            _build_codenames(_OFFICER_REF, ADD_CHANGE_VIEW)
+        ),
+    },
+    'RICD Manager': {
+        'group_type': 'MANAGER',
+        'description': 'FNC senior staff — everything Officer can do, plus delete, archive, user management, and site config.',
+        'can_approve_reports': True,
+        'can_approve_payments': True,
+        'can_manage_councils': True,
+        'can_manage_programs': True,
+        'can_manage_users': True,
+        'codenames': (
+            _build_codenames(_ALL_VIEW, VIEW) |
+            _build_codenames(_OFFICER_WRITE, ADD_CHANGE_VIEW) |
+            _build_codenames(_OFFICER_REF, FULL) |
+            _build_codenames(_MANAGER_DELETE, ['delete']) |
+            _build_codenames(_MANAGER_ADMIN, FULL)
+        ),
+    },
+    'Council Officer': {
+        'group_type': 'COUNCIL_USER',
+        'description': 'Council staff — view own-council records only; submit reports and expense claims.',
+        'can_approve_reports': False,
+        'can_approve_payments': False,
+        'can_manage_councils': False,
+        'can_manage_programs': False,
+        'can_manage_users': False,
+        'codenames': (
+            _build_codenames(_COUNCIL_VIEW, VIEW) |
+            _build_codenames(_COUNCIL_WRITE, ADD_CHANGE_VIEW)
+        ),
+    },
+    'Council Manager': {
+        'group_type': 'COUNCIL_MANAGER',
+        'description': 'Senior council staff — same scope as Council Officer (own-council data only).',
+        'can_approve_reports': False,
+        'can_approve_payments': False,
+        'can_manage_councils': False,
+        'can_manage_programs': False,
+        'can_manage_users': False,
+        'codenames': (
+            _build_codenames(_COUNCIL_VIEW, VIEW) |
+            _build_codenames(_COUNCIL_WRITE, ADD_CHANGE_VIEW)
+        ),
+    },
+    'Read Only': {
+        'group_type': 'READ_ONLY',
+        'description': 'Internal audit / finance / executives — read everything across all councils, no writes.',
+        'can_approve_reports': False,
+        'can_approve_payments': False,
+        'can_manage_councils': False,
+        'can_manage_programs': False,
+        'can_manage_users': False,
+        'codenames': _build_codenames(_ALL_VIEW, VIEW),
+    },
+}
+
+
+class Command(BaseCommand):
+    help = 'Create or update RICD permission groups with correct model-level permissions.'
+
+    def handle(self, *args, **options):
+        perm_lookup = {
+            f'{p.content_type.app_label}.{p.codename}': p
+            for p in Permission.objects.select_related('content_type').all()
+        }
+
+        for group_name, spec in GROUP_SPECS.items():
+            group, created = Group.objects.get_or_create(name=group_name)
+            action = 'Created' if created else 'Updated'
+
+            perms, missing = [], []
+            for codename in spec['codenames']:
+                p = perm_lookup.get(codename)
+                if p:
+                    perms.append(p)
+                else:
+                    missing.append(codename)
+
+            group.permissions.set(perms)
+
+            gp, _ = GroupPermission.objects.get_or_create(group=group)
+            gp.group_type = spec['group_type']
+            gp.description = spec['description']
+            gp.can_approve_reports = spec['can_approve_reports']
+            gp.can_approve_payments = spec['can_approve_payments']
+            gp.can_manage_councils = spec['can_manage_councils']
+            gp.can_manage_programs = spec['can_manage_programs']
+            gp.can_manage_users = spec['can_manage_users']
+            gp.save()
+
+            self.stdout.write(self.style.SUCCESS(
+                f'{action} "{group_name}" — {len(perms)} permissions assigned.'
+            ))
+            if missing:
+                self.stdout.write(self.style.WARNING(
+                    f'  Skipped {len(missing)} unknown codenames: '
+                    f'{", ".join(sorted(missing)[:5])}{"…" if len(missing) > 5 else ""}'
+                ))
+
+        self.stdout.write(self.style.SUCCESS('\nDone. Safe to re-run any time to resync.'))

--- a/src/apps/core/migrations/0052_workstepgroupitem_excludes_from_pc_forecast.py
+++ b/src/apps/core/migrations/0052_workstepgroupitem_excludes_from_pc_forecast.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0051_delegateposition'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='workstepgroupitem',
+            name='excludes_from_pc_forecast',
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    'When checked, this step does not participate in the sequential date chain '
+                    'and is excluded from Practical Completion date forecasting. '
+                    'Use for parallel or standalone activities (e.g. inspections, admin) that '
+                    'happen independently of the main construction sequence.'
+                ),
+            ),
+        ),
+    ]

--- a/src/apps/core/models/works_models.py
+++ b/src/apps/core/models/works_models.py
@@ -447,6 +447,7 @@ class WorkStepGroup(models.Model):
                     expected_duration_days=it.expected_duration_days,
                     stage_gate=it.stage_gate,
                     is_monthly_tracker_column=it.is_monthly_tracker_column,
+                    excludes_from_pc_forecast=it.excludes_from_pc_forecast,
                 )
             # Copy the payment milestone schedule (if any) so the clone keeps the
             # same payment timing until the user tweaks it.
@@ -476,6 +477,13 @@ class WorkStepGroupItem(models.Model):
     is_monthly_tracker_column = models.BooleanField(
         default=False,
         help_text="Show this step as a column in the monthly tracker grid"
+    )
+    excludes_from_pc_forecast = models.BooleanField(
+        default=False,
+        help_text="When checked, this step does not participate in the sequential date chain "
+                  "and is excluded from Practical Completion date forecasting. "
+                  "Use for parallel or standalone activities (e.g. inspections, admin) that "
+                  "happen independently of the main construction sequence.",
     )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/src/apps/core/services/workstep_forecast.py
+++ b/src/apps/core/services/workstep_forecast.py
@@ -15,6 +15,12 @@ Side-effect: recalculate_forecast writes the final calculated PC date back to
 Work.forecast_practical_completion_date.  forecast_handover_date is preserved
 when it was explicitly set to a date *different* from the current computed PC
 (manual target override); otherwise it tracks PC.
+
+Steps whose WorkStepGroupItem has excludes_from_pc_forecast=True are treated
+as parallel/standalone activities: they are removed from the sequential date
+chain (the cursor does not advance through them) and are excluded from PC date
+selection.  Their forecast dates are set to null since they have no sequenced
+anchor.
 """
 from datetime import timedelta
 
@@ -26,17 +32,24 @@ RECALC_UPDATE_FIELDS = frozenset({
 })
 
 
+def _is_pc_excluded(step):
+    gi = getattr(step, 'group_item', None)
+    return bool(gi and getattr(gi, 'excludes_from_pc_forecast', False))
+
+
 def _final_step(active_steps):
     """Return the step that defines the work's Practical Completion date.
 
-    Preference: the step whose source WorkStepGroupItem has stage_gate='STAGE2'.
-    Fallback: the last active step.
+    Steps flagged excludes_from_pc_forecast are ignored entirely.
+    Preference among remaining: the step with stage_gate='STAGE2'.
+    Fallback: the last non-excluded active step.
     """
-    for s in active_steps:
+    pc_steps = [s for s in active_steps if not _is_pc_excluded(s)]
+    for s in pc_steps:
         gi = getattr(s, 'group_item', None)
         if gi and getattr(gi, 'stage_gate', '') == 'STAGE2':
             return s
-    return active_steps[-1] if active_steps else None
+    return pc_steps[-1] if pc_steps else None
 
 
 def recalculate_forecast(work):
@@ -53,21 +66,30 @@ def recalculate_forecast(work):
             step.forecast_start_date = None
             step.forecast_completion_date = None
 
+    # Standalone (PC-excluded) active steps get null forecast dates — they have
+    # no sequenced anchor.
+    for step in active_steps:
+        if _is_pc_excluded(step):
+            step.forecast_start_date = None
+            step.forecast_completion_date = None
+
+    sequential_steps = [s for s in active_steps if not _is_pc_excluded(s)]
+
     start = work.actual_start_date or (work.project.start_date if work.project_id else None)
     target = work.forecast_handover_date
 
-    if start and active_steps:
+    if start and sequential_steps:
         # Forward scheduling from known start date.
         cursor = start
-        for step in active_steps:
+        for step in sequential_steps:
             step.forecast_start_date = cursor
             step.forecast_completion_date = cursor + timedelta(days=step.expected_duration_days)
             cursor = step.actual_completion_date or step.forecast_completion_date
 
-    elif target and active_steps:
+    elif target and sequential_steps:
         # Backward scheduling: anchor last step at target, cascade left.
         cursor = target
-        for step in reversed(active_steps):
+        for step in reversed(sequential_steps):
             step.forecast_completion_date = cursor
             step.forecast_start_date = cursor - timedelta(days=step.expected_duration_days)
             cursor = step.forecast_start_date

--- a/src/apps/ui/templates/help/index.html
+++ b/src/apps/ui/templates/help/index.html
@@ -165,7 +165,7 @@
       <h3>Portfolio</h3>
       <ul>
         <li><strong>Dashboard</strong> — portfolio totals, project status (on-track / late / overdue), budget, filters by council/program/status.</li>
-        <li><strong>Projects</strong> — each project's overview, its child <em>addresses &amp; works</em> (dwellings, lots, infrastructure) with costs, funding, payments, reports and documents in tabs.</li>
+        <li><strong>Projects</strong> — each project's overview, its child <em>addresses &amp; works</em> (dwellings, lots, infrastructure) with costs, funding, payments, reports and documents in tabs. The project list hides completed projects by default — tick <em>Include completed projects</em> under the State filter to show them (useful for analytics and past cashflow without cluttering active work).</li>
         <li><strong>Cashflow</strong> — forecast of committed vs released spend per program per financial year (see §6).</li>
         <li><strong>Analytics</strong> — aggregate outputs: how many dwellings by type and bedroom count, residential lots, and their costs, totalled by category, council and program.</li>
       </ul>
@@ -175,13 +175,13 @@
         <li><strong>Funding Agreements</strong> — the legal umbrella with a council.</li>
         <li><strong>Funding Schedules</strong> — the per-project funding instrument with a lifecycle (draft → ready → executed → active → superseded) and key dates that cascade to the project.</li>
         <li><strong>Payment Rules</strong> — immutable, versioned rules defining how a schedule's payments split (e.g. 30/60/10).</li>
-        <li><strong>BFA</strong> <span class="tag fnc">FNC only</span> — Brief Financial Approvals: the pre-condition that releases funding, including per-program splits and contingency.</li>
+        <li><strong>BFA</strong> <span class="tag fnc">FNC only</span> — Brief Financial Approvals: the pre-condition that releases funding, including per-program splits and contingency. The <em>Add Projects</em> button opens a picker showing only projects with a funding shortfall (total works cost exceeds approved BFA funding). A live warning appears if the sum of all row totals exceeds the selected delegate's approval limit.</li>
         <li><strong>Funding Notices &amp; Expense Claims</strong> — the capped-payment pathway; councils can submit claims against a notice.</li>
       </ul>
 
       <h3>Reports</h3>
       <ul>
-        <li><strong>Monthly Trackers</strong> — per-work construction progress grid; entering dates here drives forecasting and (now) payment timing.</li>
+        <li><strong>Monthly Trackers</strong> — per-work construction progress grid; entering dates here drives forecasting and payment timing. The Excel export uses a pivoted layout: one sheet per Work Step Group, rows are addresses/works (showing street address and "N bed Type" on two lines), and columns are the tracker steps. Green = completed (actual date recorded), yellow = fillable, grey = not applicable. Import the filled sheet back to bulk-update progress dates.</li>
         <li><strong>Quarterly Reports</strong> — FS → project → works hierarchy with expenditure and declarations, submitted to the State.</li>
         <li><strong>Stage Reports</strong> — Stage 1 / Stage 2 contract checklists that gate the next payment.</li>
       </ul>
@@ -326,7 +326,7 @@
           "Site establishment" step yet, that payment stays undated until the step (or its date) is recorded.</li>
         <li><strong>Manual always wins.</strong> Setting a payment to Manual, or typing a date, opts it out of automatic rolling.</li>
         <li><strong>Released payments are locked.</strong> Their program allocation is snapshotted at release and never retro-adjusted by later BFA changes.</li>
-        <li><strong>Costs are actual where entered, otherwise notional</strong> (estimated from per-work-type rates) — the Analytics page notes this.</li>
+        <li><strong>Cost fields on a work are per output (per unit), not totals.</strong> There are three tiers in priority order: <em>Estimated cost per output</em> (base, from notional rates or manual entry) → <em>Forecast final cost per output</em> (overrides estimated once entered) → <em>Actual cost per output</em> (authoritative once "Costs finalised" is ticked). The system multiplies whichever tier applies by the work's quantity to get the total. Entering a total instead of a per-unit cost will over-report by a factor of quantity.</li>
         <li><strong>Audit logging is automatic</strong> for financial records and cannot be edited.</li>
       </ul>
       <div class="note">

--- a/src/apps/ui/templates/work_step_groups/detail.html
+++ b/src/apps/ui/templates/work_step_groups/detail.html
@@ -78,6 +78,7 @@
           <th style="width:100px;" class="text-end">Cost %</th>
           <th style="width:160px;">Stage Gate</th>
           <th style="width:90px;" class="text-center">Tracker col?</th>
+          <th style="width:110px;" class="text-center" title="Step is excluded from the PC date forecast chain">Excl. PC forecast?</th>
           <th style="width:70px;" class="text-center">Delete</th>
         </tr>
       </thead>
@@ -104,6 +105,7 @@
             </td>
             <td>{{ form.stage_gate }}</td>
             <td class="text-center">{{ form.is_monthly_tracker_column }}</td>
+            <td class="text-center">{{ form.excludes_from_pc_forecast }}</td>
             <td class="text-center">
               {% if form.DELETE %}{{ form.DELETE }}{% endif %}
             </td>
@@ -123,6 +125,7 @@
           <td>{{ formset.empty_form.cost_percentage }}</td>
           <td>{{ formset.empty_form.stage_gate }}</td>
           <td class="text-center">{{ formset.empty_form.is_monthly_tracker_column }}</td>
+          <td class="text-center">{{ formset.empty_form.excludes_from_pc_forecast }}</td>
           <td class="text-center">{% if formset.empty_form.DELETE %}{{ formset.empty_form.DELETE }}{% endif %}</td>
         </tr>
       </tbody>

--- a/src/apps/ui/views/crud_views.py
+++ b/src/apps/ui/views/crud_views.py
@@ -3451,7 +3451,8 @@ def _workstep_group_items_formset():
     return inlineformset_factory(
         WorkStepGroup, WorkStepGroupItem,
         fields=['order', 'step', 'expected_duration_days',
-                'cost_percentage', 'stage_gate', 'is_monthly_tracker_column'],
+                'cost_percentage', 'stage_gate', 'is_monthly_tracker_column',
+                'excludes_from_pc_forecast'],
         extra=3, can_delete=True,
     )
 

--- a/src/ricdapp/settings.py
+++ b/src/ricdapp/settings.py
@@ -158,6 +158,10 @@ X_FRAME_OPTIONS = 'DENY'
 SECURE_CONTENT_TYPE_NOSNIFF = True
 CSRF_COOKIE_HTTPONLY = True
 
+_csrf_trusted = os.environ.get('DJANGO_CSRF_TRUSTED_ORIGINS', '')
+if _csrf_trusted:
+    CSRF_TRUSTED_ORIGINS = [o.strip() for o in _csrf_trusted.split(',') if o.strip()]
+
 if not DEBUG:
     SECURE_SSL_REDIRECT = True
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')


### PR DESCRIPTION
## Summary

- **`excludes_from_pc_forecast` on `WorkStepGroupItem`** — new checkbox in the Work Step Group edit grid marks a step as a standalone/parallel activity that sits outside the sequential date chain and is excluded from Practical Completion date forecasting. Steps so flagged get null forecast dates and do not advance the scheduling cursor; `_final_step()` ignores them when writing back to `Work.forecast_practical_completion_date`.
- **CSRF trusted origins** — `DJANGO_CSRF_TRUSTED_ORIGINS` env var support in `settings.py`; `EnvironmentFile=` added to systemd service for HTTPS reverse proxy deployments (YunoHost).
- **`setup_groups` management command** — creates/updates 5 Django permission groups (RICD Officer, RICD Manager, Council Officer, Council Manager, Read Only) with correct model-level permissions. Safe to re-run.
- **Help page updates** — BFA picker, completed-projects filter, monthly tracker Excel layout, and cost hierarchy documented in `/help/`.

## Test plan

- [ ] Run `python manage.py migrate` — migration `0052` should apply cleanly
- [ ] Open a Work Step Group at `/maintenance/work-step-groups/<id>/` — confirm new "Excl. PC forecast?" column appears
- [ ] Check a step as excluded, save, then open a work using that group and confirm its forecast PC date is driven only by the remaining sequential steps
- [ ] Run `python manage.py setup_groups` — should print 5 success lines, safe to run twice
- [ ] Login via HTTPS reverse proxy — CSRF should not 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)